### PR TITLE
Issue 97 top20 household

### DIFF
--- a/db/afterVersioned__MaterializedViews.sql
+++ b/db/afterVersioned__MaterializedViews.sql
@@ -1,0 +1,2 @@
+REFRESH MATERIALIZED VIEW top20_mn_per_country;
+REFRESH MATERIALIZED VIEW top20_mn_per_hhsurvey;

--- a/db/objects/R__070_top20_mn_per_country.sql
+++ b/db/objects/R__070_top20_mn_per_country.sql
@@ -1,4 +1,5 @@
-CREATE OR REPLACE VIEW top20_mn_per_country AS
+DROP MATERIALIZED VIEW IF EXISTS top20_mn_per_country;
+CREATE MATERIALIZED VIEW top20_mn_per_country AS
 
 SELECT b.* , food_genus.food_name
 FROM (
@@ -74,4 +75,4 @@ ORDER BY country_id, mn_name, ranking asc
 ;
 
 
-COMMENT ON VIEW top20_mn_per_country IS 'View showing the rankings of how much each food genus contributes to a particular micronutrient intake in a particular country and data set.'
+COMMENT ON MATERIALIZED VIEW top20_mn_per_country IS 'View showing the rankings of how much each food genus contributes to a particular micronutrient intake in a particular country and data set.'

--- a/db/objects/R__070_top20_mn_per_country.sql
+++ b/db/objects/R__070_top20_mn_per_country.sql
@@ -10,7 +10,7 @@ FROM (
 				, fct_source_id
 				, data_source_id
 				, mn_name
-			ORDER BY mn_consumed_per_day desc
+			ORDER BY mn_consumed_per_day desc NULLS LAST
 		) as ranking
 	FROM (
 		SELECT

--- a/db/objects/R__075_top20_mn_per_household_survey.sql
+++ b/db/objects/R__075_top20_mn_per_household_survey.sql
@@ -1,4 +1,5 @@
-CREATE OR REPLACE VIEW top20_mn_per_hhsurvey AS
+DROP MATERIALIZED VIEW IF EXISTS top20_mn_per_hhsurvey;
+CREATE MATERIALIZED VIEW top20_mn_per_hhsurvey AS
 
 SELECT b.* , food_genus.food_name
 FROM (
@@ -75,4 +76,4 @@ ORDER BY survey_id, mn_name, ranking asc
 ;
 
 
-COMMENT ON VIEW top20_mn_per_country IS 'View showing the rankings of how much each food genus contributes to a particular micronutrient intake in a particular household consumption survey.'
+COMMENT ON MATERIALIZED VIEW top20_mn_per_country IS 'View showing the rankings of how much each food genus contributes to a particular micronutrient intake in a particular household consumption survey.'

--- a/db/objects/R__075_top20_mn_per_household_survey.sql
+++ b/db/objects/R__075_top20_mn_per_household_survey.sql
@@ -76,4 +76,4 @@ ORDER BY survey_id, mn_name, ranking asc
 ;
 
 
-COMMENT ON MATERIALIZED VIEW top20_mn_per_country IS 'View showing the rankings of how much each food genus contributes to a particular micronutrient intake in a particular household consumption survey.'
+COMMENT ON MATERIALIZED VIEW top20_mn_per_hhsurvey IS 'View showing the rankings of how much each food genus contributes to a particular micronutrient intake in a particular household consumption survey.'

--- a/db/objects/R__075_top20_mn_per_household_survey.sql
+++ b/db/objects/R__075_top20_mn_per_household_survey.sql
@@ -1,0 +1,78 @@
+CREATE OR REPLACE VIEW top20_mn_per_hhsurvey AS
+
+SELECT b.* , food_genus.food_name
+FROM (
+	SELECT
+		*
+		, row_number() over (
+			PARTITION BY
+				survey_id
+				, fct_source_id
+				-- , data_source_id
+				, mn_name
+			ORDER BY mn_consumed_per_day desc NULLS LAST
+		) as ranking
+	FROM (
+		SELECT
+			household.survey_id
+			, fi.fct_source_id
+			-- , cc.data_source_id
+			, mn.mn_name
+			, fi.food_genus_id
+			, sum( (mn.mn_value / 100 * amount_consumed_in_g) ) / 365  AS mn_consumed_per_day
+		FROM food_genus_nutrients fi
+		CROSS JOIN LATERAL (
+			VALUES
+				('A'           , VitaminA_in_RAE_in_mcg     ),
+				('B6'          , VitaminB6_in_mg            ),
+				('B12'         , VitaminB12_in_mcg          ),
+				('C'           , VitaminC_in_mg             ),
+				('D'           , VitaminD_in_mcg            ),
+				('E'           , VitaminE_in_mg             ),
+				('B1'          , Thiamin_in_mg              ),
+				('B2'          , Riboflavin_in_mg           ),
+				('B3'          , Niacin_in_mg               ),
+				('Folic Acid'  , Folicacid_in_mcg           ),
+				('B9'          , Folate_in_mcg              ),
+				('B5'          , Pantothenate_in_mg         ),
+				('B7'          , Biotin_in_mcg              ),
+				('IP6'         , PhyticAcid_in_mg           ),
+				('Ca'          , Ca_in_mg                   ),
+				('Cu'          , Cu_in_mg                   ),
+				('Fe'          , Fe_in_mg                   ),
+				('Mg'          , Mg_in_mg                   ),
+				('Mn'          , Mn_in_mcg                  ),
+				('P'           , P_in_mg                    ),
+				('K'           , K_in_mg                    ),
+				('Na'          , Na_in_mg                   ),
+				('Zn'          , Zn_in_mg                   ),
+				('I'           , I_in_mcg                   ),
+				('N'           , Nitrogen_in_g              ),
+				('Se'          , Se_in_mcg                  ),
+				('Ash'         , Ash_in_g                   ),
+				('Fibre'       , Fibre_in_g                 ),
+				('Carbohydrate', Carbohydrateavailable_in_g ),
+				('Cholesterol' , Cholesterol_in_mg          ),
+				('Protein'     , TotalProtein_in_g          ),
+				('Fat'         , TotalFats_in_g             ),
+				('Energy'      , Energy_in_kCal             ),
+				('Moisture'    , Moisture_in_g              )
+		) AS mn("mn_name", "mn_value")
+		JOIN household_consumption hc ON hc.food_genus_id = fi.food_genus_id
+        JOIN household ON hc.household_id = household.id
+        JOIN survey ON household.survey_id = survey.id
+		-- WHERE date_part('year', hc.date_consumed) = 2018
+		GROUP BY
+			household.survey_id
+			, fi.food_genus_id
+			, fi.fct_source_id
+			, mn_name
+	) a
+) b
+JOIN food_genus ON b.food_genus_id = food_genus.id
+WHERE ranking <= 20
+ORDER BY survey_id, mn_name, ranking asc
+;
+
+
+COMMENT ON VIEW top20_mn_per_country IS 'View showing the rankings of how much each food genus contributes to a particular micronutrient intake in a particular household consumption survey.'


### PR DESCRIPTION
- Add view to show top20 foods for household surveys. There is missing data, so several micronutirents will give a rank, but it is nonsense because the actual consumption data is NULL. This could be misleading, and we may want to open an issue to discuss what to do in such cases. I'm currently assuming that this will be fixed when we get better food composition data, but might not.
- fixed issue where foods with NULL consumption were placed in rank 1
- Made both top20 views into materialized views, because they took a long time (~15 secs for hh survey) to select data
- Repeatable migrations only run when their script file checksum changes. Therefore, I've added a callback that refreshes the materialized views very time there is a versioned migration; this should catch data updates in the future

closes #97 