### PR TITLE
Consolidate views for selecting 'best' data sources for a given country

### DIFF
--- a/db/objects/Biomarker/V0.1.0.650__biomarker_mn_lookup.sql
+++ b/db/objects/Biomarker/V0.1.0.650__biomarker_mn_lookup.sql
@@ -1,0 +1,21 @@
+CREATE TABLE biomarker_micronutrient_mapping (
+	biomarker_name               text primary key
+    , micronutrient_id           text REFERENCES micronutrient (id);
+
+COMMENT ON TABLE  biomarker_name IS 'Name of the biomarker';
+COMMENT ON COLUMN micronutrient_id IS 'ID of the corresponding micronutrient from the micronutrients table';
+
+INSERT INTO biomarker_micronutrient_mapping (biomarker_name, micronutrient_id)
+VALUES
+ ('haemoglobin'), 'Fe')
+,('ferritin', 'Fe' )
+,('stfr', 'Fe' )
+,('rbp', null )
+,('retinol'), null )
+,('rbc_folate', 'B9' )
+,('ps_folate', 'B9' )
+,('vitamin_b12', 'B12' )
+,('zinc', 'Zn' )
+,('crp', null )
+,('agp', null )
+,('iodine', 'I' );

--- a/db/objects/R__037_fct_reported_mn.sql
+++ b/db/objects/R__037_fct_reported_mn.sql
@@ -1,0 +1,46 @@
+create or replace view fct_reported_micronutrients as
+select fct_source_id, 
+
+       string_to_array(
+       		CONCAT_WS(',', 
+				CASE WHEN sum(VitaminA_in_RAE_in_mcg) IS NULL THEN NULL ELSE 'A' END,
+				CASE WHEN sum(VitaminB6_in_mg) IS NULL THEN NULL ELSE 'B6' END,
+				CASE WHEN sum(VitaminB12_in_mcg) IS NULL THEN NULL ELSE 'B12' END,
+				CASE WHEN sum(VitaminC_in_mg) IS NULL THEN NULL ELSE 'C' END,
+				CASE WHEN sum(VitaminD_in_mcg) IS NULL THEN NULL ELSE 'D' END,
+				CASE WHEN sum(VitaminE_in_mg) IS NULL THEN NULL ELSE 'E' END,
+				CASE WHEN sum(Thiamin_in_mg) IS NULL THEN NULL ELSE 'B1' END,
+				CASE WHEN sum(Riboflavin_in_mg) IS NULL THEN NULL ELSE 'B2' END,
+				CASE WHEN sum(Niacin_in_mg) IS NULL THEN NULL ELSE 'B3' END,
+				CASE WHEN sum(Folicacid_in_mcg) IS NULL THEN NULL ELSE 'Folic Acid' END,
+				CASE WHEN sum(Folate_in_mcg) IS NULL THEN NULL ELSE 'B9' END,
+				CASE WHEN sum(Pantothenate_in_mg) IS NULL THEN NULL ELSE 'B5' END,
+				CASE WHEN sum(Biotin_in_mcg) IS NULL THEN NULL ELSE 'B7' END,
+				CASE WHEN sum(PhyticAcid_in_mg) IS NULL THEN NULL ELSE 'IP6' END,
+				CASE WHEN sum(Ca_in_mg) IS NULL THEN NULL ELSE 'Ca' END,
+				CASE WHEN sum(Cu_in_mg) IS NULL THEN NULL ELSE 'Cu' END,
+				CASE WHEN sum(Fe_in_mg) IS NULL THEN NULL ELSE 'Fe' END,
+				CASE WHEN sum(Mg_in_mg) IS NULL THEN NULL ELSE 'Mg' END,
+				CASE WHEN sum(Mn_in_mcg) IS NULL THEN NULL ELSE 'Mn' END,
+				CASE WHEN sum(P_in_mg) IS NULL THEN NULL ELSE 'P' END,
+				CASE WHEN sum(K_in_mg) IS NULL THEN NULL ELSE 'K' END,
+				CASE WHEN sum(Na_in_mg) IS NULL THEN NULL ELSE 'Na' END,
+				CASE WHEN sum(Zn_in_mg) IS NULL THEN NULL ELSE 'Zn' END,
+				CASE WHEN sum(I_in_mcg) IS NULL THEN NULL ELSE 'I' END,
+				CASE WHEN sum(Nitrogen_in_g) IS NULL THEN NULL ELSE 'N' END,
+				CASE WHEN sum(Se_in_mcg) IS NULL THEN NULL ELSE 'Se' END,
+				CASE WHEN sum(Ash_in_g) IS NULL THEN NULL ELSE 'Ash' END,
+				CASE WHEN sum(Fibre_in_g) IS NULL THEN NULL ELSE 'Fibre' END,
+				CASE WHEN sum(carbohydrates_in_g) IS NULL THEN NULL ELSE 'Carbohydrate' END,
+				CASE WHEN sum(Cholesterol_in_mg) IS NULL THEN NULL ELSE 'Cholesterol' END,
+				CASE WHEN sum(TotalProtein_in_g) IS NULL THEN NULL ELSE 'Protein' END,
+				CASE WHEN sum(TotalFats_in_g) IS NULL THEN NULL ELSE 'Fat' END,
+				CASE WHEN sum(Energy_in_kCal) IS NULL THEN NULL ELSE 'Energy' END,
+				CASE WHEN sum(Moisture_in_g) IS NULL THEN NULL ELSE 'Moisture' end
+			)
+       , ',')
+       AS "reported_micronutrients"
+
+from fooditem group by fct_source_id;
+
+COMMENT ON VIEW fct_reported_micronutrients IS 'View of array of reported micronutrients for a given FCT';

--- a/db/objects/R__038_survey_reported_biomarker
+++ b/db/objects/R__038_survey_reported_biomarker
@@ -1,0 +1,34 @@
+create or replace view survey_reported_biomarkers as
+
+with survey_measurements as 
+(
+select h.survey_id, bm.* from biomarker_measurement bm 
+join household_member hm 
+on bm.household_member_id=hm.id
+join household h 
+on hm.household_id = h.id
+)
+
+select survey_id, 
+
+       string_to_array(
+       		CONCAT_WS(',', 
+				CASE WHEN sum(haemoglobin) IS NULL THEN NULL ELSE 'haemoglobin' END,
+				CASE WHEN sum(ferritin) IS NULL THEN NULL ELSE 'ferritin' END,
+				CASE WHEN sum(stfr) IS NULL THEN NULL ELSE 'stfr' END,
+				CASE WHEN sum(rbp) IS NULL THEN NULL ELSE 'rbp' END,
+				CASE WHEN sum(retinol) IS NULL THEN NULL ELSE 'retinol' END,
+				CASE WHEN sum(rbc_folate) IS NULL THEN NULL ELSE 'rbc_folate' END,
+				CASE WHEN sum(ps_folate) IS NULL THEN NULL ELSE 'ps_folate' END,
+				CASE WHEN sum(vitamin_b12) IS NULL THEN NULL ELSE 'vitamin_b12' END,
+				CASE WHEN sum(zinc) IS NULL THEN NULL ELSE 'zinc' END,
+				CASE WHEN sum(crp) IS NULL THEN NULL ELSE 'crp' END,
+				CASE WHEN sum(agp) IS NULL THEN NULL ELSE 'agp' END,
+				CASE WHEN sum(iodine) IS NULL THEN NULL ELSE 'iodine' END
+			)
+       , ',')
+       AS "reported_biomarkers"
+
+from survey_measurements group by survey_id;
+
+COMMENT ON VIEW survey_reported_biomarkers IS 'View of array of reported biomarkers for a given biomarker survey';

--- a/db/objects/R__040_composition_sources.sql
+++ b/db/objects/R__040_composition_sources.sql
@@ -17,7 +17,7 @@ join fct_source on ST_COVERS(ST_ENVELOPE(fct_source.geometry), country.geometry)
 join fct_reported_micronutrients frm on fct_source.id=frm.fct_source_id 
 CROSS  JOIN unnest (frm.reported_micronutrients) micronutrient_id
 )
-select rank, micronutrient_id, composition_data_id, composition_data_name, country_id from fcts
+select country_id, micronutrient_id, composition_data_id, composition_data_name from fcts
 where rank = 1;
 
 COMMENT ON VIEW composition_data_sources IS 'View of simplified algorithm for "best" FCT for a given country';

--- a/db/objects/R__040_composition_sources.sql
+++ b/db/objects/R__040_composition_sources.sql
@@ -10,7 +10,7 @@ with fcts as (
 			, publication_date desc) 
             as rank
 
-from country left join fct_source on ST_COVERS(ST_ENVELOPE(fct_source.geometry), country.geometry)
+from country join fct_source on ST_COVERS(ST_ENVELOPE(fct_source.geometry), country.geometry)
 )
 select composition_data_id, composition_data_name, country_id from fcts where fcts.rank=1;
 

--- a/db/objects/R__040_composition_sources.sql
+++ b/db/objects/R__040_composition_sources.sql
@@ -4,14 +4,20 @@ with fcts as (
         fct_source.id as composition_data_id
         , fct_source.name as composition_data_name
         , country.id as country_id
+        , frm.reported_micronutrients 
+        , micronutrient_id 
         , ROW_NUMBER() over 
-          (partition by country.id order BY			
+          (partition by country.id, micronutrient_id order BY			
 			ST_AREA(fct_source.geometry) ASC
 			, publication_date desc) 
             as rank
 
-from country join fct_source on ST_COVERS(ST_ENVELOPE(fct_source.geometry), country.geometry)
+from country 
+join fct_source on ST_COVERS(ST_ENVELOPE(fct_source.geometry), country.geometry)
+join fct_reported_micronutrients frm on fct_source.id=frm.fct_source_id 
+CROSS  JOIN unnest (frm.reported_micronutrients) micronutrient_id
 )
-select composition_data_id, composition_data_name, country_id from fcts where fcts.rank=1;
+select rank, micronutrient_id, composition_data_id, composition_data_name, country_id from fcts
+where rank = 1;
 
 COMMENT ON VIEW composition_data_sources IS 'View of simplified algorithm for "best" FCT for a given country';

--- a/db/objects/R__045_biomarker_sources.sql
+++ b/db/objects/R__045_biomarker_sources.sql
@@ -1,0 +1,25 @@
+CREATE OR REPLACE VIEW biomarker_data_sources AS
+with surveys as (
+    select 
+        survey.id as survey_id
+        , the_biomarker_name as biomarker_name
+        , micronutrient_id
+        , survey.name as survey_name
+        , country.id as country_id
+        , ROW_NUMBER() over                    --negate rank
+          (partition by country.id, the_biomarker_name order BY			
+			ST_AREA(survey.geometry) ASC
+			, publication_date desc
+			) 
+            as rank
+
+from country join survey on ST_COVERS(ST_ENVELOPE(survey.geometry), country.geometry)
+join survey_reported_biomarkers srb on survey.id=srb.survey_id 
+CROSS  JOIN unnest (srb.reported_biomarkers) as the_biomarker_name
+join biomarker_micronutrient_mapping bmm on the_biomarker_name=bmm.biomarker_name
+where survey.survey_type = 'biomarker' 
+)
+select country_id, biomarker_name, micronutrient_id, survey_id, survey_name from surveys
+where rank = 1;
+
+COMMENT ON VIEW composition_data_sources IS 'View of simplified algorithm for "best" biomarker data source for a given country';

--- a/db/objects/R__045_biomarker_sources.sql
+++ b/db/objects/R__045_biomarker_sources.sql
@@ -22,4 +22,4 @@ where survey.survey_type = 'biomarker'
 select country_id, biomarker_name, micronutrient_id, survey_id, survey_name from surveys
 where rank = 1;
 
-COMMENT ON VIEW composition_data_sources IS 'View of simplified algorithm for "best" biomarker data source for a given country';
+COMMENT ON VIEW biomarker_data_sources IS 'View of simplified algorithm for "best" biomarker data source for a given country';

--- a/db/objects/R__050_consumption_sources.sql
+++ b/db/objects/R__050_consumption_sources.sql
@@ -12,7 +12,7 @@ with country_consumption as (
 			, publication_date desc) 
             as rank
 
-from country left join country_consumption_source on ST_COVERS(ST_ENVELOPE(country_consumption_source.geometry), country.geometry)
+from country join country_consumption_source on ST_COVERS(ST_ENVELOPE(country_consumption_source.geometry), country.geometry)
 )
 , household_consumption as (
     select 
@@ -27,6 +27,7 @@ from country left join country_consumption_source on ST_COVERS(ST_ENVELOPE(count
             as rank
 
 from country join survey on ST_COVERS(ST_ENVELOPE(survey.geometry), country.geometry)
+where survey.survey_type = 'food consumption' 
 ),
 combined as (
 select * from household_consumption where rank=-1

--- a/db/objects/R__060_diet_data_sources.sql
+++ b/db/objects/R__060_diet_data_sources.sql
@@ -1,6 +1,7 @@
 create or replace view diet_data_sources as 
 
 select comds.country_id
+, micronutrient_id
 , consumption_data_type
 , consumption_data_id
 , composition_data_id


### PR DESCRIPTION
These are the basic views for selecting a single FCT, FBS, HCES survey or biomarker survey for a given nation.  It doesn't cover @spenny-liam new FCT fallthrough work.

*   Fix consumption data sources and composition data sources views to not include countries with no data
*   Add reported micronutrients for each FCT and pivot these into the composition sources view so can select by country and micronutrient
*   Add view for biomarker surveys also included pivoted biomarker names to allow querying by country and biomarker and/or corresponding micronutrient ID