### PR TITLE
chore: fix data scales when at annual/daily level

### DIFF
--- a/db/dictionary-data/R__impact-commodity-aggregation.sql
+++ b/db/dictionary-data/R__impact-commodity-aggregation.sql
@@ -8,7 +8,7 @@ CREATE MATERIALIZED VIEW impact_commodity_aggregation as
         , scenario
         , commodity
         , year
-        , calcium AS value
+        , calcium / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, impact_commodity.name AS commodity, country, calcium, row_number() OVER (
@@ -25,7 +25,7 @@ CREATE MATERIALIZED VIEW impact_commodity_aggregation as
         , scenario
         , 'Other' AS commodity
         , year
-        , sum(calcium) AS value
+        , sum(calcium) / 365 AS value
         , 6 AS rank 
         FROM (
             SELECT year, scenario, commodity, country, calcium, row_number() OVER (
@@ -43,7 +43,7 @@ UNION
         , scenario
         , commodity
         , year
-        , folate AS value
+        , folate / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, impact_commodity.name AS commodity, country, folate, row_number() OVER (
@@ -60,7 +60,7 @@ UNION
         , scenario
         , 'Other' AS commodity
         , year
-        , sum(folate) AS value
+        , sum(folate) / 365 AS value
         , 6 AS rank 
         FROM (
             SELECT year, scenario, commodity, country, folate, row_number() OVER (
@@ -78,7 +78,7 @@ UNION
         , scenario
         , commodity
         , year
-        , iron AS value
+        , iron / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, impact_commodity.name AS commodity, country, iron, row_number() OVER (
@@ -95,7 +95,7 @@ UNION
         , scenario
         , 'Other' AS commodity
         , year
-        , sum(iron) AS value
+        , sum(iron) / 365 AS value
         , 6 AS rank 
         FROM (
             SELECT year, scenario, commodity, country, iron, row_number() OVER (
@@ -113,7 +113,7 @@ UNION
         , scenario
         , commodity
         , year
-        , magnesium AS value
+        , magnesium / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, impact_commodity.name AS commodity, country, magnesium, row_number() OVER (
@@ -130,7 +130,7 @@ UNION
         , scenario
         , 'Other' AS commodity
         , year
-        , sum(magnesium) AS value
+        , sum(magnesium) / 365 AS value
         , 6 AS rank 
         FROM (
             SELECT year, scenario, commodity, country, magnesium, row_number() OVER (
@@ -148,7 +148,7 @@ UNION
         , scenario
         , commodity
         , year
-        , niacin AS value
+        , niacin / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, impact_commodity.name AS commodity, country, niacin, row_number() OVER (
@@ -165,7 +165,7 @@ UNION
         , scenario
         , 'Other' AS commodity
         , year
-        , sum(niacin) AS value
+        , sum(niacin) / 365 AS value
         , 6 AS rank 
         FROM (
             SELECT year, scenario, commodity, country, niacin, row_number() OVER (
@@ -183,7 +183,7 @@ UNION
         , scenario
         , commodity
         , year
-        , phosphorus AS value
+        , phosphorus / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, impact_commodity.name AS commodity, country, phosphorus, row_number() OVER (
@@ -200,7 +200,7 @@ UNION
         , scenario
         , 'Other' AS commodity
         , year
-        , sum(phosphorus) AS value
+        , sum(phosphorus) / 365 AS value
         , 6 AS rank 
         FROM (
             SELECT year, scenario, commodity, country, phosphorus, row_number() OVER (
@@ -218,7 +218,7 @@ UNION
         , scenario
         , commodity
         , year
-        , potassium AS value
+        , potassium / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, impact_commodity.name AS commodity, country, potassium, row_number() OVER (
@@ -235,7 +235,7 @@ UNION
         , scenario
         , 'Other' AS commodity
         , year
-        , sum(potassium) AS value
+        , sum(potassium) / 365 AS value
         , 6 AS rank 
         FROM (
             SELECT year, scenario, commodity, country, potassium, row_number() OVER (
@@ -253,7 +253,7 @@ UNION
         , scenario
         , commodity
         , year
-        , protein AS value
+        , protein / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, impact_commodity.name AS commodity, country, protein, row_number() OVER (
@@ -270,7 +270,7 @@ UNION
         , scenario
         , 'Other' AS commodity
         , year
-        , sum(protein) AS value
+        , sum(protein) / 365 AS value
         , 6 AS rank 
         FROM (
             SELECT year, scenario, commodity, country, protein, row_number() OVER (
@@ -288,7 +288,7 @@ UNION
         , scenario
         , commodity
         , year
-        , riboflavin AS value
+        , riboflavin / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, impact_commodity.name AS commodity, country, riboflavin, row_number() OVER (
@@ -305,7 +305,7 @@ UNION
         , scenario
         , 'Other' AS commodity
         , year
-        , sum(riboflavin) AS value
+        , sum(riboflavin) / 365 AS value
         , 6 AS rank 
         FROM (
             SELECT year, scenario, commodity, country, riboflavin, row_number() OVER (
@@ -323,7 +323,7 @@ UNION
         , scenario
         , commodity
         , year
-        , thiamin AS value
+        , thiamin / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, impact_commodity.name AS commodity, country, thiamin, row_number() OVER (
@@ -340,7 +340,7 @@ UNION
         , scenario
         , 'Other' AS commodity
         , year
-        , sum(thiamin) AS value
+        , sum(thiamin) / 365 AS value
         , 6 AS rank 
         FROM (
             SELECT year, scenario, commodity, country, thiamin, row_number() OVER (
@@ -358,7 +358,7 @@ UNION
         , scenario
         , commodity
         , year
-        , vit_a AS value
+        , vit_a / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, impact_commodity.name AS commodity, country, vit_a, row_number() OVER (
@@ -375,7 +375,7 @@ UNION
         , scenario
         , 'Other' AS commodity
         , year
-        , sum(vit_a) AS value
+        , sum(vit_a) / 365 AS value
         , 6 AS rank 
         FROM (
             SELECT year, scenario, commodity, country, vit_a, row_number() OVER (
@@ -393,7 +393,7 @@ UNION
         , scenario
         , commodity
         , year
-        , vit_b6 AS value
+        , vit_b6 / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, impact_commodity.name AS commodity, country, vit_b6, row_number() OVER (
@@ -410,7 +410,7 @@ UNION
         , scenario
         , 'Other' AS commodity
         , year
-        , sum(vit_b6) AS value
+        , sum(vit_b6) / 365 AS value
         , 6 AS rank 
         FROM (
             SELECT year, scenario, commodity, country, vit_b6, row_number() OVER (
@@ -428,7 +428,7 @@ UNION
         , scenario
         , commodity
         , year
-        , vit_c AS value
+        , vit_c / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, impact_commodity.name AS commodity, country, vit_c, row_number() OVER (
@@ -445,7 +445,7 @@ UNION
         , scenario
         , 'Other' AS commodity
         , year
-        , sum(vit_c) AS value
+        , sum(vit_c) / 365 AS value
         , 6 AS rank 
         FROM (
             SELECT year, scenario, commodity, country, vit_c, row_number() OVER (
@@ -463,7 +463,7 @@ UNION
         , scenario
         , commodity
         , year
-        , zinc AS value
+        , zinc / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, impact_commodity.name AS commodity, country, zinc, row_number() OVER (
@@ -480,7 +480,7 @@ UNION
         , scenario
         , 'Other' AS commodity
         , year
-        , sum(zinc) AS value
+        , sum(zinc) / 365 AS value
         , 6 AS rank 
         FROM (
             SELECT year, scenario, commodity, country, zinc, row_number() OVER (

--- a/db/dictionary-data/R__impact-food-group-aggregation.sql
+++ b/db/dictionary-data/R__impact-food-group-aggregation.sql
@@ -8,7 +8,7 @@ CREATE MATERIALIZED VIEW impact_food_group_aggregation as
         , scenario
         , food_group
         , year
-        , calcium AS value
+        , calcium / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(calcium) as calcium, row_number() OVER (
@@ -27,7 +27,7 @@ CREATE MATERIALIZED VIEW impact_food_group_aggregation as
         , scenario
         , 'Other' as food_group
         , year
-        , sum(calcium) AS value
+        , sum(calcium) / 365 AS value
         , 6 as rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(calcium) as calcium, row_number() OVER (
@@ -48,7 +48,7 @@ UNION
         , scenario
         , food_group
         , year
-        , folate AS value
+        , folate / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(folate) as folate, row_number() OVER (
@@ -67,7 +67,7 @@ UNION
         , scenario
         , 'Other' as food_group
         , year
-        , sum(folate) AS value
+        , sum(folate) / 365 AS value
         , 6 as rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(folate) as folate, row_number() OVER (
@@ -88,7 +88,7 @@ UNION
         , scenario
         , food_group
         , year
-        , iron AS value
+        , iron / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(iron) as iron, row_number() OVER (
@@ -107,7 +107,7 @@ UNION
         , scenario
         , 'Other' as food_group
         , year
-        , sum(iron) AS value
+        , sum(iron) / 365 AS value
         , 6 as rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(iron) as iron, row_number() OVER (
@@ -128,7 +128,7 @@ UNION
         , scenario
         , food_group
         , year
-        , magnesium AS value
+        , magnesium / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(magnesium) as magnesium, row_number() OVER (
@@ -147,7 +147,7 @@ UNION
         , scenario
         , 'Other' as food_group
         , year
-        , sum(magnesium) AS value
+        , sum(magnesium) / 365 AS value
         , 6 as rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(magnesium) as magnesium, row_number() OVER (
@@ -168,7 +168,7 @@ UNION
         , scenario
         , food_group
         , year
-        , niacin AS value
+        , niacin / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(niacin) as niacin, row_number() OVER (
@@ -187,7 +187,7 @@ UNION
         , scenario
         , 'Other' as food_group
         , year
-        , sum(niacin) AS value
+        , sum(niacin) / 365 AS value
         , 6 as rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(niacin) as niacin, row_number() OVER (
@@ -208,7 +208,7 @@ UNION
         , scenario
         , food_group
         , year
-        , phosphorus AS value
+        , phosphorus / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(phosphorus) as phosphorus, row_number() OVER (
@@ -227,7 +227,7 @@ UNION
         , scenario
         , 'Other' as food_group
         , year
-        , sum(phosphorus) AS value
+        , sum(phosphorus) / 365 AS value
         , 6 as rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(phosphorus) as phosphorus, row_number() OVER (
@@ -248,7 +248,7 @@ UNION
         , scenario
         , food_group
         , year
-        , potassium AS value
+        , potassium / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(potassium) as potassium, row_number() OVER (
@@ -267,7 +267,7 @@ UNION
         , scenario
         , 'Other' as food_group
         , year
-        , sum(potassium) AS value
+        , sum(potassium) / 365 AS value
         , 6 as rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(potassium) as potassium, row_number() OVER (
@@ -288,7 +288,7 @@ UNION
         , scenario
         , food_group
         , year
-        , protein AS value
+        , protein / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(protein) as protein, row_number() OVER (
@@ -307,7 +307,7 @@ UNION
         , scenario
         , 'Other' as food_group
         , year
-        , sum(protein) AS value
+        , sum(protein) / 365 AS value
         , 6 as rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(protein) as protein, row_number() OVER (
@@ -328,7 +328,7 @@ UNION
         , scenario
         , food_group
         , year
-        , riboflavin AS value
+        , riboflavin / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(riboflavin) as riboflavin, row_number() OVER (
@@ -347,7 +347,7 @@ UNION
         , scenario
         , 'Other' as food_group
         , year
-        , sum(riboflavin) AS value
+        , sum(riboflavin) / 365 AS value
         , 6 as rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(riboflavin) as riboflavin, row_number() OVER (
@@ -368,7 +368,7 @@ UNION
         , scenario
         , food_group
         , year
-        , thiamin AS value
+        , thiamin / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(thiamin) as thiamin, row_number() OVER (
@@ -387,7 +387,7 @@ UNION
         , scenario
         , 'Other' as food_group
         , year
-        , sum(thiamin) AS value
+        , sum(thiamin) / 365 AS value
         , 6 as rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(thiamin) as thiamin, row_number() OVER (
@@ -408,7 +408,7 @@ UNION
         , scenario
         , food_group
         , year
-        , vit_a AS value
+        , vit_a / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(vit_a) as vit_a, row_number() OVER (
@@ -427,7 +427,7 @@ UNION
         , scenario
         , 'Other' as food_group
         , year
-        , sum(vit_a) AS value
+        , sum(vit_a) / 365 AS value
         , 6 as rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(vit_a) as vit_a, row_number() OVER (
@@ -448,7 +448,7 @@ UNION
         , scenario
         , food_group
         , year
-        , vit_b6 AS value
+        , vit_b6 / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(vit_b6) as vit_b6, row_number() OVER (
@@ -467,7 +467,7 @@ UNION
         , scenario
         , 'Other' as food_group
         , year
-        , sum(vit_b6) AS value
+        , sum(vit_b6) / 365 AS value
         , 6 as rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(vit_b6) as vit_b6, row_number() OVER (
@@ -488,7 +488,7 @@ UNION
         , scenario
         , food_group
         , year
-        , vit_c AS value
+        , vit_c / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(vit_c) as vit_c, row_number() OVER (
@@ -507,7 +507,7 @@ UNION
         , scenario
         , 'Other' as food_group
         , year
-        , sum(vit_c) AS value
+        , sum(vit_c) / 365 AS value
         , 6 as rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(vit_c) as vit_c, row_number() OVER (
@@ -528,7 +528,7 @@ UNION
         , scenario
         , food_group
         , year
-        , zinc AS value
+        , zinc / 365 AS value
         , rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(zinc) as zinc, row_number() OVER (
@@ -547,7 +547,7 @@ UNION
         , scenario
         , 'Other' as food_group
         , year
-        , sum(zinc) AS value
+        , sum(zinc) / 365 AS value
         , 6 as rank 
         FROM (
             SELECT year, scenario, food_group.name as food_group, country, sum(zinc) as zinc, row_number() OVER (

--- a/db/objects/R__070_top20_mn_per_country.sql
+++ b/db/objects/R__070_top20_mn_per_country.sql
@@ -23,7 +23,7 @@ FROM (
 			, cc.data_source_id
 			, mn.mn_name
 			, fi.food_genus_id
-			, sum( (mn.mn_value / 100 * amount_consumed_in_g) ) / 365  AS mn_consumed_per_day
+			, sum( (mn.mn_value / 100 * amount_consumed_in_g) )  AS mn_consumed_per_day
 		FROM food_genus_nutrients fi
 		CROSS JOIN LATERAL (
 			VALUES

--- a/db/objects/R__075_top20_mn_per_household_survey.sql
+++ b/db/objects/R__075_top20_mn_per_household_survey.sql
@@ -22,7 +22,7 @@ FROM (
 			-- , cc.data_source_id
 			, mn.mn_name
 			, fi.food_genus_id
-			, sum( (mn.mn_value / 100 * amount_consumed_in_g) ) / 365  AS mn_consumed_per_day
+			, sum( (mn.mn_value / 100 * amount_consumed_in_g) )  AS mn_consumed_per_day
 		FROM food_genus_nutrients fi
 		CROSS JOIN LATERAL (
 			VALUES

--- a/db/objects/country/R__033_mn_bin_range.sql
+++ b/db/objects/country/R__033_mn_bin_range.sql
@@ -1,0 +1,14 @@
+create or replace view mn_bin_range as
+
+select 
+micronutrient_id
+, power(10,floor(log(max(dietary_supply)))) as scale
+, 0 as bin0
+, ((ceiling(max(dietary_supply)/power(10,floor(log(max(dietary_supply)))))*power(10,floor(log(max(dietary_supply)))))/5)*1 as bin1
+, ((ceiling(max(dietary_supply)/power(10,floor(log(max(dietary_supply)))))*power(10,floor(log(max(dietary_supply)))))/5)*2 as bin2
+, ((ceiling(max(dietary_supply)/power(10,floor(log(max(dietary_supply)))))*power(10,floor(log(max(dietary_supply)))))/5)*3 as bin3
+, ((ceiling(max(dietary_supply)/power(10,floor(log(max(dietary_supply)))))*power(10,floor(log(max(dietary_supply)))))/5)*4 as bin4
+, ((ceiling(max(dietary_supply)/power(10,floor(log(max(dietary_supply)))))*power(10,floor(log(max(dietary_supply)))))/5)*5 as bin5
+, ceiling(max(dietary_supply)/power(10,floor(log(max(dietary_supply)))))*power(10,floor(log(max(dietary_supply)))) as binmax
+, max(dietary_supply)
+, min(dietary_supply) from country_deficiency_afe cda group by micronutrient_id;

--- a/db/objects/impact/R__033_impact_summary.sql
+++ b/db/objects/impact/R__033_impact_summary.sql
@@ -5,11 +5,11 @@ SELECT
     , micronutrient.id as micronutrient
    	, impact_scenario.id as scenario
     , intake_threshold.rda as recommended
-    , interpolate_impact_year.reference_val / 365 as daily_reference_val
+    , interpolate_impact_year.reference_val as daily_reference_val
     , interpolate_impact_year.reference_year
     , interpolate_impact_year.intersect_year
 	, -1 * round(
-			((intake_threshold.rda - (interpolate_impact_year.reference_val / 365)) / intake_threshold.rda) * 100,
+			((intake_threshold.rda - (interpolate_impact_year.reference_val)) / intake_threshold.rda) * 100,
 		2
 	) as difference
 FROM


### PR DESCRIPTION
Some views incorrectly scaled or didn't data by annum rather than day.  This PR hopefully ensures a consistent set of views for micronutrient availabilities and other breakdowns to be reported per day