### PR TITLE
Add summary views for extracting intervention data rows in a useful format

### DIFF
--- a/db/objects/intervention_costings/R__099_json_object_aggregate.sql
+++ b/db/objects/intervention_costings/R__099_json_object_aggregate.sql
@@ -1,0 +1,10 @@
+--New aggregate function to support aggregation of
+--json objects into a single json object
+--
+-- See: https://dba.stackexchange.com/questions/255127/merging-many-jsonb-objects-using-aggregate-functions-in-postgresql
+--      https://faraday.ai/blog/how-to-aggregate-jsonb-in-postgres/
+CREATE or replace AGGREGATE jsonb_object_aggregate(jsonb) (
+    SFUNC = 'jsonb_concat',
+    STYPE = jsonb,
+    INITCOND = '{}'
+);

--- a/db/objects/intervention_costings/R__100_interventions-list.sql
+++ b/db/objects/intervention_costings/R__100_interventions-list.sql
@@ -1,9 +1,8 @@
-create
-or replace view intervention_list as
+create or replace view intervention_list as
 select
     i.id,
     i.intervention_name as name,
-    'No description available' as description,
+    coalesce(i.description, 'No description available') as description,
     i.country_id,
     i.fortification_type_id,
     ft."name" as fortification_type_name,
@@ -27,7 +26,5 @@ from
     intervention i
     join fortification_type ft on ft.id = i.fortification_type_id
     join food_vehicle fv on fv.id = i.food_vehicle_id
-where
-    is_premade = true;
 
-comment on view intervention_list is 'View of premade interventions and summary attributes';
+comment on view intervention_list is 'View of interventions and summary attributes';

--- a/db/objects/intervention_costings/R__100_interventions-list.sql
+++ b/db/objects/intervention_costings/R__100_interventions-list.sql
@@ -1,0 +1,33 @@
+create
+or replace view intervention_list as
+select
+    i.id,
+    i.intervention_name as name,
+    'No description available' as description,
+    i.country_id,
+    i.fortification_type_id,
+    ft."name" as fortification_type_name,
+    i.program_status,
+    i.food_vehicle_id,
+    fv.vehicle_name as food_vehicle_name,
+    i.base_year,
+    round(
+        (
+            select
+                year_0
+            from
+                intervention_data d
+            where
+                d.row_name = 'summary_10yr_discounted_startup_and_recurring_cost'
+                and d.intervention_id = i.id
+        ),
+        0
+    ) as ten_year_total_cost
+from
+    intervention i
+    join fortification_type ft on ft.id = i.fortification_type_id
+    join food_vehicle fv on fv.id = i.food_vehicle_id
+where
+    is_premade = true;
+
+comment on view intervention_list is 'View of premade interventions and summary attributes';

--- a/db/objects/intervention_costings/R__101_intervention-baseline-assumptions.sql
+++ b/db/objects/intervention_costings/R__101_intervention-baseline-assumptions.sql
@@ -1,85 +1,84 @@
 CREATE
 OR REPLACE view intervention_baseline_assumptions AS WITH fortifiable AS (
-    with fortifiable as (
-        select
-            intervention_id,
-            json_build_object(
-                'title',
-                factor_text,
-                'year0',
-                year_0,
-                'year1',
-                year_1,
-                'year2',
-                year_2,
-                'year3',
-                year_3,
-                'year4',
-                year_4,
-                'year5',
-                year_5,
-                'year6',
-                year_6,
-                'year7',
-                year_7,
-                'year8',
-                year_8,
-                'year9',
-                year_9,
-                'rowIndex',
-                row_index
-            ) as potentially_fortifiable
-        from
-            intervention_data d
-        where
-            d.row_name = 'fortifiable_vehicle_pct'
-            and d.header1 = 'Program assumptions'
-    ),
-    fortified as (
-        select
-            intervention_id,
-            json_build_object(
-                'title',
-                factor_text,
-                'year0',
-                year_0,
-                'year1',
-                year_1,
-                'year2',
-                year_2,
-                'year3',
-                year_3,
-                'year4',
-                year_4,
-                'year5',
-                year_5,
-                'year6',
-                year_6,
-                'year7',
-                year_7,
-                'year8',
-                year_8,
-                'year9',
-                year_9,
-                'rowIndex',
-                row_index
-            ) as actually_fortified
-        from
-            intervention_data d
-        where
-            d.row_name = 'fortified_fortifiable_vehicle_pct'
-            and d.header1 = 'Program assumptions'
-    )
     select
-        pf.intervention_id,
+        intervention_id,
         json_build_object(
-            'potentiallyFortified',
-            potentially_fortifiable,
-            'actuallyFortified',
-            actually_fortified
-        ) as baseline_assumptions
+            'title',
+            factor_text,
+            'year0',
+            year_0,
+            'year1',
+            year_1,
+            'year2',
+            year_2,
+            'year3',
+            year_3,
+            'year4',
+            year_4,
+            'year5',
+            year_5,
+            'year6',
+            year_6,
+            'year7',
+            year_7,
+            'year8',
+            year_8,
+            'year9',
+            year_9,
+            'rowIndex',
+            row_index
+        ) as potentially_fortifiable
     from
-        fortifiable pf
-        join fortified af on pf.intervention_id = af.intervention_id;
+        intervention_data d
+    where
+        d.row_name = 'fortifiable_vehicle_pct'
+        and d.header1 = 'Program assumptions'
+),
+fortified as (
+    select
+        intervention_id,
+        json_build_object(
+            'title',
+            factor_text,
+            'year0',
+            year_0,
+            'year1',
+            year_1,
+            'year2',
+            year_2,
+            'year3',
+            year_3,
+            'year4',
+            year_4,
+            'year5',
+            year_5,
+            'year6',
+            year_6,
+            'year7',
+            year_7,
+            'year8',
+            year_8,
+            'year9',
+            year_9,
+            'rowIndex',
+            row_index
+        ) as actually_fortified
+    from
+        intervention_data d
+    where
+        d.row_name = 'fortified_fortifiable_vehicle_pct'
+        and d.header1 = 'Program assumptions'
+)
+select
+    pf.intervention_id,
+    json_build_object(
+        'potentiallyFortified',
+        potentially_fortifiable,
+        'actuallyFortified',
+        actually_fortified
+    ) as baseline_assumptions
+from
+    fortifiable pf
+    join fortified af on pf.intervention_id = af.intervention_id;
 
 comment ON view intervention_baseline_assumptions IS 'Extract baseline assumptions (potentially fortified/actually fortified) rows for a given intervention';

--- a/db/objects/intervention_costings/R__101_intervention-baseline-assumptions.sql
+++ b/db/objects/intervention_costings/R__101_intervention-baseline-assumptions.sql
@@ -1,5 +1,5 @@
-CREATE
-OR REPLACE view intervention_baseline_assumptions AS WITH fortifiable AS (
+CREATE OR REPLACE view intervention_baseline_assumptions AS 
+WITH fortifiable AS (
     select
         intervention_id,
         json_build_object(

--- a/db/objects/intervention_costings/R__101_intervention-baseline-assumptions.sql
+++ b/db/objects/intervention_costings/R__101_intervention-baseline-assumptions.sql
@@ -1,0 +1,85 @@
+CREATE
+OR REPLACE view intervention_baseline_assumptions AS WITH fortifiable AS (
+    with fortifiable as (
+        select
+            intervention_id,
+            json_build_object(
+                'title',
+                factor_text,
+                'year0',
+                year_0,
+                'year1',
+                year_1,
+                'year2',
+                year_2,
+                'year3',
+                year_3,
+                'year4',
+                year_4,
+                'year5',
+                year_5,
+                'year6',
+                year_6,
+                'year7',
+                year_7,
+                'year8',
+                year_8,
+                'year9',
+                year_9,
+                'rowIndex',
+                row_index
+            ) as potentially_fortifiable
+        from
+            intervention_data d
+        where
+            d.row_name = 'fortifiable_vehicle_pct'
+            and d.header1 = 'Program assumptions'
+    ),
+    fortified as (
+        select
+            intervention_id,
+            json_build_object(
+                'title',
+                factor_text,
+                'year0',
+                year_0,
+                'year1',
+                year_1,
+                'year2',
+                year_2,
+                'year3',
+                year_3,
+                'year4',
+                year_4,
+                'year5',
+                year_5,
+                'year6',
+                year_6,
+                'year7',
+                year_7,
+                'year8',
+                year_8,
+                'year9',
+                year_9,
+                'rowIndex',
+                row_index
+            ) as actually_fortified
+        from
+            intervention_data d
+        where
+            d.row_name = 'fortified_fortifiable_vehicle_pct'
+            and d.header1 = 'Program assumptions'
+    )
+    select
+        pf.intervention_id,
+        json_build_object(
+            'potentiallyFortified',
+            potentially_fortifiable,
+            'actuallyFortified',
+            actually_fortified
+        ) as baseline_assumptions
+    from
+        fortifiable pf
+        join fortified af on pf.intervention_id = af.intervention_id;
+
+comment ON view intervention_baseline_assumptions IS 'Extract baseline assumptions (potentially fortified/actually fortified) rows for a given intervention';

--- a/db/objects/intervention_costings/R__102_intervention-vehicle-standard.sql
+++ b/db/objects/intervention_costings/R__102_intervention-vehicle-standard.sql
@@ -1,5 +1,5 @@
-CREATE
-OR REPLACE view intervention_vehicle_standard AS with food_vehicle as (
+CREATE OR REPLACE view intervention_vehicle_standard AS 
+with food_vehicle as (
     select
         intervention_id,
         split_part(
@@ -11,7 +11,7 @@ OR REPLACE view intervention_vehicle_standard AS with food_vehicle as (
         year_0 as target_val,
         row_index
     from
-        intervention_data id
+        intervention_data
     where
         header1 = 'Program assumptions'
         and row_name is null

--- a/db/objects/intervention_costings/R__102_intervention-vehicle-standard.sql
+++ b/db/objects/intervention_costings/R__102_intervention-vehicle-standard.sql
@@ -17,24 +17,40 @@ OR REPLACE view intervention_vehicle_standard AS with food_vehicle as (
         and row_name is null
     order by
         row_index asc
+),
+fvs as (
+    select
+        intervention_id,
+        micronutrient,
+        json_agg(
+            json_build_object(
+                'compound',
+                compound,
+                'targetVal',
+                target_val,
+                'rowIndex',
+                row_index
+            )
+        ) as food_vehicle_standard
+    from
+        food_vehicle fv
+    group by
+        intervention_id,
+        micronutrient
 )
 select
     intervention_id,
-    micronutrient,
-    json_agg(
+    array_agg(
         json_build_object(
-            'compound',
-            compound,
-            'targetVal',
-            target_val,
-            'rowIndex',
-            row_index
+            'micronutrient',
+            micronutrient,
+            'compounds',
+            food_vehicle_standard
         )
     ) as food_vehicle_standard
 from
-    food_vehicle fv
+    fvs
 group by
-    intervention_id,
-    micronutrient;
+    intervention_id;
 
 comment ON view intervention_vehicle_standard IS 'Extract intervention vehicle standards rows for a given intervention';

--- a/db/objects/intervention_costings/R__102_intervention-vehicle-standard.sql
+++ b/db/objects/intervention_costings/R__102_intervention-vehicle-standard.sql
@@ -1,0 +1,40 @@
+CREATE
+OR REPLACE view intervention_vehicle_standard AS with food_vehicle as (
+    select
+        intervention_id,
+        split_part(
+            split_part(factor_text, 'Food vehicle standard, ', 2),
+            '(',
+            1
+        ) as micronutrient,
+        split_part(split_part(factor_text, '(', 2), ')', 1) as compound,
+        year_0 as target_val,
+        row_index
+    from
+        intervention_data id
+    where
+        header1 = 'Program assumptions'
+        and row_name is null
+    order by
+        row_index asc
+)
+select
+    intervention_id,
+    micronutrient,
+    json_agg(
+        json_build_object(
+            'compound',
+            compound,
+            'targetVal',
+            target_val,
+            'rowIndex',
+            row_index
+        )
+    ) as food_vehicle_standard
+from
+    food_vehicle fv
+group by
+    intervention_id,
+    micronutrient;
+
+comment ON view intervention_vehicle_standard IS 'Extract intervention vehicle standards rows for a given intervention';

--- a/db/objects/intervention_costings/R__103_intervention-values-json.sql
+++ b/db/objects/intervention_costings/R__103_intervention-values-json.sql
@@ -1,11 +1,10 @@
-CREATE
-OR REPLACE VIEW intervention_values_json AS
+CREATE OR REPLACE VIEW intervention_values_json AS
 SELECT
     intervention_data.intervention_id,
     intervention_data.header1,
     COALESCE(
-        NULLIF(intervention_data.header2, '' :: text),
-        'All' :: text
+        NULLIF(intervention_data.header2, ''),
+        'All'
     ) AS header2,
     json_agg(
         json_build_object(

--- a/db/objects/intervention_costings/R__103_intervention-values-json.sql
+++ b/db/objects/intervention_costings/R__103_intervention-values-json.sql
@@ -48,4 +48,4 @@ GROUP BY
     intervention_data.header1,
     intervention_data.header2;
 
-comment ON view intervention_baseline_assumptions IS 'Aggregate intervention_data year fields into json object';
+comment ON view intervention_values_json IS 'Aggregate intervention_data year fields into json object';

--- a/db/objects/intervention_costings/R__103_intervention-values-json.sql
+++ b/db/objects/intervention_costings/R__103_intervention-values-json.sql
@@ -40,7 +40,7 @@ SELECT
             intervention_data.row_index
     ) AS data
 FROM
-    bmgf.intervention_data
+    intervention_data
 WHERE
     intervention_data.header1 IS NOT NULL
 GROUP BY

--- a/db/objects/intervention_costings/R__103_intervention-values-json.sql
+++ b/db/objects/intervention_costings/R__103_intervention-values-json.sql
@@ -1,0 +1,51 @@
+CREATE
+OR REPLACE VIEW intervention_values_json AS
+SELECT
+    intervention_data.intervention_id,
+    intervention_data.header1,
+    COALESCE(
+        NULLIF(intervention_data.header2, '' :: text),
+        'All' :: text
+    ) AS header2,
+    json_agg(
+        json_build_object(
+            'rowIndex',
+            intervention_data.row_index,
+            'labelText',
+            intervention_data.factor_text,
+            'rowName',
+            intervention_data.row_name,
+            'year0',
+            intervention_data.year_0,
+            'year1',
+            intervention_data.year_1,
+            'year2',
+            intervention_data.year_2,
+            'year3',
+            intervention_data.year_3,
+            'year4',
+            intervention_data.year_4,
+            'year5',
+            intervention_data.year_5,
+            'year6',
+            intervention_data.year_6,
+            'year7',
+            intervention_data.year_7,
+            'year8',
+            intervention_data.year_8,
+            'year9',
+            intervention_data.year_9
+        )
+        ORDER BY
+            intervention_data.row_index
+    ) AS data
+FROM
+    bmgf.intervention_data
+WHERE
+    intervention_data.header1 IS NOT NULL
+GROUP BY
+    intervention_data.intervention_id,
+    intervention_data.header1,
+    intervention_data.header2;
+
+comment ON view intervention_baseline_assumptions IS 'Aggregate intervention_data year fields into json object';

--- a/db/objects/intervention_costings/R__104_intervention-industry-info.sql
+++ b/db/objects/intervention_costings/R__104_intervention-industry-info.sql
@@ -41,4 +41,4 @@ from
 where
     section = 'Industry information';
 
-comment ON view intervention_baseline_assumptions IS 'Extract industry information rows for a given intervention';
+comment ON view intervention_industry_information IS 'Extract industry information rows for a given intervention';

--- a/db/objects/intervention_costings/R__104_intervention-industry-info.sql
+++ b/db/objects/intervention_costings/R__104_intervention-industry-info.sql
@@ -1,0 +1,44 @@
+CREATE
+or replace AGGREGATE jsonb_object_aggregate(jsonb) (
+    SFUNC = 'jsonb_concat',
+    STYPE = jsonb,
+    INITCOND = '{}'
+);
+
+CREATE
+OR REPLACE view intervention_industry_information AS with h2_agg as (
+    select
+        intervention_id,
+        header1,
+        header2,
+        jsonb_object_agg(
+            header2,
+            to_jsonb(t) - 'header2' - 'header1' - 'intervention_id'
+        ) res
+    from
+        intervention_values_json t
+    group by
+        intervention_id,
+        header1,
+        header2
+),
+intervention_data_json_aggregate as (
+    select
+        intervention_id,
+        header1 as section,
+        jsonb_object_aggregate(res) as data
+    from
+        h2_agg
+    group by
+        header1,
+        intervention_id
+)
+select
+    intervention_id,
+    data -> 'All'
+from
+    intervention_data_json_aggregate
+where
+    section = 'Industry information';
+
+comment ON view intervention_baseline_assumptions IS 'Extract industry information rows for a given intervention';

--- a/db/objects/intervention_costings/R__104_intervention-industry-info.sql
+++ b/db/objects/intervention_costings/R__104_intervention-industry-info.sql
@@ -1,12 +1,5 @@
-CREATE
-or replace AGGREGATE jsonb_object_aggregate(jsonb) (
-    SFUNC = 'jsonb_concat',
-    STYPE = jsonb,
-    INITCOND = '{}'
-);
-
-CREATE
-OR REPLACE view intervention_industry_information AS with h2_agg as (
+CREATE OR REPLACE view intervention_industry_information AS 
+with h2_agg as (
     select
         intervention_id,
         header1,

--- a/db/objects/intervention_costings/R__104_intervention-industry-info.sql
+++ b/db/objects/intervention_costings/R__104_intervention-industry-info.sql
@@ -35,7 +35,7 @@ intervention_data_json_aggregate as (
 )
 select
     intervention_id,
-    data -> 'All'
+    data -> 'All' -> 'data' as industry_information
 from
     intervention_data_json_aggregate
 where

--- a/db/objects/intervention_costings/R__105_intervetion-monitoring-info.sql
+++ b/db/objects/intervention_costings/R__105_intervetion-monitoring-info.sql
@@ -35,7 +35,7 @@ intervention_data_json_aggregate as (
 )
 select
     intervention_id,
-    data -> 'All'
+    data -> 'All' -> 'data' as monitoring_information
 from
     intervention_data_json_aggregate
 where

--- a/db/objects/intervention_costings/R__105_intervetion-monitoring-info.sql
+++ b/db/objects/intervention_costings/R__105_intervetion-monitoring-info.sql
@@ -1,12 +1,5 @@
-CREATE
-or replace AGGREGATE jsonb_object_aggregate(jsonb) (
-    SFUNC = 'jsonb_concat',
-    STYPE = jsonb,
-    INITCOND = '{}'
-);
-
-CREATE
-OR REPLACE view intervention_monitoring_information AS with h2_agg as (
+CREATE OR REPLACE view intervention_monitoring_information AS 
+with h2_agg as (
     select
         intervention_id,
         header1,

--- a/db/objects/intervention_costings/R__105_intervetion-monitoring-info.sql
+++ b/db/objects/intervention_costings/R__105_intervetion-monitoring-info.sql
@@ -1,0 +1,44 @@
+CREATE
+or replace AGGREGATE jsonb_object_aggregate(jsonb) (
+    SFUNC = 'jsonb_concat',
+    STYPE = jsonb,
+    INITCOND = '{}'
+);
+
+CREATE
+OR REPLACE view intervention_industry_information AS with h2_agg as (
+    select
+        intervention_id,
+        header1,
+        header2,
+        jsonb_object_agg(
+            header2,
+            to_jsonb(t) - 'header2' - 'header1' - 'intervention_id'
+        ) res
+    from
+        intervention_values_json t
+    group by
+        intervention_id,
+        header1,
+        header2
+),
+intervention_data_json_aggregate as (
+    select
+        intervention_id,
+        header1 as section,
+        jsonb_object_aggregate(res) as data
+    from
+        h2_agg
+    group by
+        header1,
+        intervention_id
+)
+select
+    intervention_id,
+    data -> 'All'
+from
+    intervention_data_json_aggregate
+where
+    section = 'Program monitoring information';
+
+comment ON view intervention_baseline_assumptions IS 'Extract industry information rows for a given intervention';

--- a/db/objects/intervention_costings/R__105_intervetion-monitoring-info.sql
+++ b/db/objects/intervention_costings/R__105_intervetion-monitoring-info.sql
@@ -6,7 +6,7 @@ or replace AGGREGATE jsonb_object_aggregate(jsonb) (
 );
 
 CREATE
-OR REPLACE view intervention_industry_information AS with h2_agg as (
+OR REPLACE view intervention_monitoring_information AS with h2_agg as (
     select
         intervention_id,
         header1,
@@ -41,4 +41,4 @@ from
 where
     section = 'Program monitoring information';
 
-comment ON view intervention_baseline_assumptions IS 'Extract industry information rows for a given intervention';
+comment ON view intervention_monitoring_information IS 'Extract industry information rows for a given intervention';

--- a/db/objects/intervention_costings/R__106_intervention-susu-costs.sql
+++ b/db/objects/intervention_costings/R__106_intervention-susu-costs.sql
@@ -125,7 +125,7 @@ su_agg2 as (
 )
 select
     intervention_id,
-    array_agg(startup_scaleup_costs)
+    array_agg(startup_scaleup_costs) as startup_scaleup_costs
 from
     su_agg2
 group by

--- a/db/objects/intervention_costings/R__106_intervention-susu-costs.sql
+++ b/db/objects/intervention_costings/R__106_intervention-susu-costs.sql
@@ -100,9 +100,7 @@ su_agg2 as (
     select
         intervention_id,
         header1,
-        json_build_object('category', header1, 'costs', array_agg(d)) as startup_scaleup_costs --header1,
-        --header2,	
-        --array_agg(d),
+        json_build_object('category', header1, 'costs', array_agg(d)) as startup_scaleup_costs
     from
         gov_su_agg
     where

--- a/db/objects/intervention_costings/R__106_intervention-susu-costs.sql
+++ b/db/objects/intervention_costings/R__106_intervention-susu-costs.sql
@@ -1,12 +1,5 @@
-CREATE
-or replace AGGREGATE jsonb_object_aggregate(jsonb) (
-    SFUNC = 'jsonb_concat',
-    STYPE = jsonb,
-    INITCOND = '{}'
-);
-
-CREATE
-OR REPLACE view intervention_startup_scaleup_costs AS with totalfields as (
+CREATE OR REPLACE view intervention_startup_scaleup_costs AS 
+with totalfields as (
     select
         '{
 		"Industry start-up/scale-up costs": {

--- a/db/objects/intervention_costings/R__106_intervention-susu-costs.sql
+++ b/db/objects/intervention_costings/R__106_intervention-susu-costs.sql
@@ -1,0 +1,123 @@
+CREATE
+or replace AGGREGATE jsonb_object_aggregate(jsonb) (
+    SFUNC = 'jsonb_concat',
+    STYPE = jsonb,
+    INITCOND = '{}'
+);
+
+CREATE
+OR REPLACE view intervention_startup_scaleup_costs AS with totalfields as (
+    select
+        '{
+		"Industry start-up/scale-up costs": {
+			"Equipment": "total_equipment_cost",
+			"Labeling": "total_labeling_cost",
+			"Training": "total_training_cost"
+		},
+		"Industry-related start-up/scale-up costs": {
+			"Equipment": "total_equipment_cost",
+			"Labeling": "total_labeling_cost",
+			"Training": "total_training_cost"
+		}, 
+		"Government-related start-up/scale-up costs": {
+			"Equipment": "total_equipment_cost_gov",
+			"Planning": "total_planning_cost",
+			"Social marketing and advocacy": "total_social_marketing_startup_cost",
+			"Training ": "total_training_cost_gov"
+		},
+		"Government start-up/scale-up costs": {
+			"Equipment": "total_equipment_cost_gov",
+			"Planning": "total_planning_cost",
+			"Social marketing and advocacy": "total_social_marketing_startup_cost",
+			"Training ": "total_training_cost_gov"
+		}
+}' :: json as mapping
+),
+gov_su as (
+    select
+        intervention_id,
+        header1,
+        header2,
+        json_build_object(
+            'name',
+            factor_text,
+            'rowIndex',
+            row_index,
+            'year0',
+            year_0,
+            'year1',
+            year_1
+        ) as data
+    from
+        intervention_data id
+),
+gov_su_agg as (
+    select
+        intervention_id,
+        header1,
+        json_build_object(
+            header2,
+            json_build_object(
+                'breakdown',
+                json_agg(data),
+                'year0Total',
+                (
+                    select
+                        year_0
+                    from
+                        intervention_data id2
+                    where
+                        intervention_id = g.intervention_id
+                        and header1 = g.header1
+                        and header2 = g.header2
+                        and row_name =(
+                            select
+                                mapping ->(g.header1) ->>(g.header2)
+                            from
+                                totalfields
+                        )
+                ),
+                'year1Total',
+                (
+                    select
+                        year_1
+                    from
+                        intervention_data id2
+                    where
+                        intervention_id = g.intervention_id
+                        and header1 = g.header1
+                        and header2 = g.header2
+                        and row_name =(
+                            select
+                                mapping ->(g.header1) ->>(g.header2)
+                            from
+                                totalfields
+                        )
+                )
+            )
+        ) as d
+    from
+        gov_su g
+    group by
+        header1,
+        header2,
+        intervention_id
+)
+select
+    intervention_id,
+    header1,
+    jsonb_object_aggregate(d :: jsonb)
+from
+    gov_su_agg
+where
+    header1 in (
+        'Industry start-up/scale-up costs',
+        'Industry-related start-up/scale-up costs',
+        'Government-related start-up/scale-up costs',
+        'Government start-up/scale-up costs'
+    )
+group by
+    intervention_id,
+    header1;
+
+comment ON view intervention_startup_scaleup_costs IS 'Extract intervention start-up/scale-up rows for a given intervention';

--- a/db/objects/intervention_costings/R__106_intervention-susu-costs.sql
+++ b/db/objects/intervention_costings/R__106_intervention-susu-costs.sql
@@ -55,45 +55,45 @@ gov_su_agg as (
     select
         intervention_id,
         header1,
+        header2,
         json_build_object(
+            'section',
             header2,
-            json_build_object(
-                'breakdown',
-                json_agg(data),
-                'year0Total',
-                (
-                    select
-                        year_0
-                    from
-                        intervention_data id2
-                    where
-                        intervention_id = g.intervention_id
-                        and header1 = g.header1
-                        and header2 = g.header2
-                        and row_name =(
-                            select
-                                mapping ->(g.header1) ->>(g.header2)
-                            from
-                                totalfields
-                        )
-                ),
-                'year1Total',
-                (
-                    select
-                        year_1
-                    from
-                        intervention_data id2
-                    where
-                        intervention_id = g.intervention_id
-                        and header1 = g.header1
-                        and header2 = g.header2
-                        and row_name =(
-                            select
-                                mapping ->(g.header1) ->>(g.header2)
-                            from
-                                totalfields
-                        )
-                )
+            'costBreakdown',
+            json_agg(data),
+            'year0Total',
+            (
+                select
+                    year_0
+                from
+                    intervention_data id2
+                where
+                    intervention_id = g.intervention_id
+                    and header1 = g.header1
+                    and header2 = g.header2
+                    and row_name =(
+                        select
+                            mapping ->(g.header1) ->>(g.header2)
+                        from
+                            totalfields
+                    )
+            ),
+            'year1Total',
+            (
+                select
+                    year_1
+                from
+                    intervention_data id2
+                where
+                    intervention_id = g.intervention_id
+                    and header1 = g.header1
+                    and header2 = g.header2
+                    and row_name =(
+                        select
+                            mapping ->(g.header1) ->>(g.header2)
+                        from
+                            totalfields
+                    )
             )
         ) as d
     from
@@ -102,22 +102,33 @@ gov_su_agg as (
         header1,
         header2,
         intervention_id
+),
+su_agg2 as (
+    select
+        intervention_id,
+        header1,
+        json_build_object('category', header1, 'costs', array_agg(d)) as startup_scaleup_costs --header1,
+        --header2,	
+        --array_agg(d),
+    from
+        gov_su_agg
+    where
+        header1 in (
+            'Industry start-up/scale-up costs',
+            'Industry-related start-up/scale-up costs',
+            'Government-related start-up/scale-up costs',
+            'Government start-up/scale-up costs'
+        )
+    group by
+        intervention_id,
+        header1
 )
 select
     intervention_id,
-    header1,
-    jsonb_object_aggregate(d :: jsonb)
+    array_agg(startup_scaleup_costs)
 from
-    gov_su_agg
-where
-    header1 in (
-        'Industry start-up/scale-up costs',
-        'Industry-related start-up/scale-up costs',
-        'Government-related start-up/scale-up costs',
-        'Government start-up/scale-up costs'
-    )
+    su_agg2
 group by
-    intervention_id,
-    header1;
+    intervention_id;
 
 comment ON view intervention_startup_scaleup_costs IS 'Extract intervention start-up/scale-up rows for a given intervention';

--- a/db/objects/intervention_costings/R__107_intervention-recurring-costs.sql
+++ b/db/objects/intervention_costings/R__107_intervention-recurring-costs.sql
@@ -1,0 +1,271 @@
+CREATE
+or replace AGGREGATE jsonb_object_aggregate(jsonb) (
+    SFUNC = 'jsonb_concat',
+    STYPE = jsonb,
+    INITCOND = '{}'
+);
+
+CREATE
+OR REPLACE view intervention_recurring_costs AS with totalfields as (
+    select
+        '{
+		"Recurring premix costs": {
+			"Premix": "total_premix_cost"
+		},
+		"Government-related recurring monitoring and management costs ": {
+			"Mill inspections and monitoring": "total_factory_inspections_cost",
+			"Import monitoring": "???",
+			"Commercial monitoring/market surveys": "???",
+			"Household monitoring  ": "total_household_monitoring_cost",
+			"Social marketing": "total_social_marketing_recurring_cost",
+			"Training/Retraining": "total_retraining_gov_cost",
+			"Management, overhead, administration ": "total_management_cost_gov"
+		},
+		"Industry-related recurring fortification costs": {
+			"Fortification": "total_fortification_cost",
+			"Internal quality assurance/quality control (QA/QC)": "total_internal_qaqc_cost",
+			"External quality assurance/quality control (QA/QC)": "total_external_qaqc_cost",
+			"Training/Retraining": "total_retraining_cost",
+			"Management, overhead, administration ": "total_management_cost"
+		}
+}' :: json as mapping
+),
+gov_su as (
+    select
+        intervention_id,
+        header1,
+        header2,
+        json_build_object(
+            'name',
+            factor_text,
+            'rowIndex',
+            row_index,
+            'year0',
+            year_0,
+            'year1',
+            year_1,
+            'year2',
+            year_2,
+            'year3',
+            year_3,
+            'year4',
+            year_4,
+            'year5',
+            year_5,
+            'year6',
+            year_6,
+            'year7',
+            year_7,
+            'year8',
+            year_8,
+            'year9',
+            year_9
+        ) as data
+    from
+        intervention_data id --where header1 = 'Government-related start-up/scale-up costs' --and header2 = 'Planning'
+),
+gov_su_agg as (
+    select
+        intervention_id,
+        header1,
+        json_build_object(
+            header2,
+            json_build_object(
+                'breakdown',
+                json_agg(data),
+                'year0Total',
+                (
+                    select
+                        year_0
+                    from
+                        intervention_data id2
+                    where
+                        intervention_id = g.intervention_id
+                        and header1 = g.header1
+                        and header2 = g.header2
+                        and row_name =(
+                            select
+                                mapping ->(g.header1) ->>(g.header2)
+                            from
+                                totalfields
+                        )
+                ),
+                'year1Total',
+                (
+                    select
+                        year_1
+                    from
+                        intervention_data id2
+                    where
+                        intervention_id = g.intervention_id
+                        and header1 = g.header1
+                        and header2 = g.header2
+                        and row_name =(
+                            select
+                                mapping ->(g.header1) ->>(g.header2)
+                            from
+                                totalfields
+                        )
+                ),
+                'year2Total',
+                (
+                    select
+                        year_2
+                    from
+                        intervention_data id2
+                    where
+                        intervention_id = g.intervention_id
+                        and header1 = g.header1
+                        and header2 = g.header2
+                        and row_name =(
+                            select
+                                mapping ->(g.header1) ->>(g.header2)
+                            from
+                                totalfields
+                        )
+                ),
+                'year3Total',
+                (
+                    select
+                        year_3
+                    from
+                        intervention_data id2
+                    where
+                        intervention_id = g.intervention_id
+                        and header1 = g.header1
+                        and header2 = g.header2
+                        and row_name =(
+                            select
+                                mapping ->(g.header1) ->>(g.header2)
+                            from
+                                totalfields
+                        )
+                ),
+                'year4Total',
+                (
+                    select
+                        year_4
+                    from
+                        intervention_data id2
+                    where
+                        intervention_id = g.intervention_id
+                        and header1 = g.header1
+                        and header2 = g.header2
+                        and row_name =(
+                            select
+                                mapping ->(g.header1) ->>(g.header2)
+                            from
+                                totalfields
+                        )
+                ),
+                'year5Total',
+                (
+                    select
+                        year_5
+                    from
+                        intervention_data id2
+                    where
+                        intervention_id = g.intervention_id
+                        and header1 = g.header1
+                        and header2 = g.header2
+                        and row_name =(
+                            select
+                                mapping ->(g.header1) ->>(g.header2)
+                            from
+                                totalfields
+                        )
+                ),
+                'year6Total',
+                (
+                    select
+                        year_6
+                    from
+                        intervention_data id2
+                    where
+                        intervention_id = g.intervention_id
+                        and header1 = g.header1
+                        and header2 = g.header2
+                        and row_name =(
+                            select
+                                mapping ->(g.header1) ->>(g.header2)
+                            from
+                                totalfields
+                        )
+                ),
+                'year7Total',
+                (
+                    select
+                        year_7
+                    from
+                        intervention_data id2
+                    where
+                        intervention_id = g.intervention_id
+                        and header1 = g.header1
+                        and header2 = g.header2
+                        and row_name =(
+                            select
+                                mapping ->(g.header1) ->>(g.header2)
+                            from
+                                totalfields
+                        )
+                ),
+                'year8Total',
+                (
+                    select
+                        year_8
+                    from
+                        intervention_data id2
+                    where
+                        intervention_id = g.intervention_id
+                        and header1 = g.header1
+                        and header2 = g.header2
+                        and row_name =(
+                            select
+                                mapping ->(g.header1) ->>(g.header2)
+                            from
+                                totalfields
+                        )
+                ),
+                'year9Total',
+                (
+                    select
+                        year_9
+                    from
+                        intervention_data id2
+                    where
+                        intervention_id = g.intervention_id
+                        and header1 = g.header1
+                        and header2 = g.header2
+                        and row_name =(
+                            select
+                                mapping ->(g.header1) ->>(g.header2)
+                            from
+                                totalfields
+                        )
+                )
+            )
+        ) as d
+    from
+        gov_su g
+    group by
+        header1,
+        header2,
+        intervention_id
+)
+select
+    intervention_id,
+    header1,
+    jsonb_object_aggregate(d :: jsonb)
+from
+    gov_su_agg
+where
+    header1 in (
+        'Recurring premix costs',
+        'Government-related recurring monitoring and management costs ',
+        'Industry-related recurring fortification costs'
+    )
+group by
+    intervention_id,
+    header1;
+
+comment ON view intervention_recurring_costs IS 'Extract intervention recurring cost rows for a given intervention';

--- a/db/objects/intervention_costings/R__107_intervention-recurring-costs.sql
+++ b/db/objects/intervention_costings/R__107_intervention-recurring-costs.sql
@@ -68,181 +68,181 @@ gov_su_agg as (
     select
         intervention_id,
         header1,
+        header2,
         json_build_object(
+            'section',
             header2,
-            json_build_object(
-                'breakdown',
-                json_agg(data),
-                'year0Total',
-                (
-                    select
-                        year_0
-                    from
-                        intervention_data id2
-                    where
-                        intervention_id = g.intervention_id
-                        and header1 = g.header1
-                        and header2 = g.header2
-                        and row_name =(
-                            select
-                                mapping ->(g.header1) ->>(g.header2)
-                            from
-                                totalfields
-                        )
-                ),
-                'year1Total',
-                (
-                    select
-                        year_1
-                    from
-                        intervention_data id2
-                    where
-                        intervention_id = g.intervention_id
-                        and header1 = g.header1
-                        and header2 = g.header2
-                        and row_name =(
-                            select
-                                mapping ->(g.header1) ->>(g.header2)
-                            from
-                                totalfields
-                        )
-                ),
-                'year2Total',
-                (
-                    select
-                        year_2
-                    from
-                        intervention_data id2
-                    where
-                        intervention_id = g.intervention_id
-                        and header1 = g.header1
-                        and header2 = g.header2
-                        and row_name =(
-                            select
-                                mapping ->(g.header1) ->>(g.header2)
-                            from
-                                totalfields
-                        )
-                ),
-                'year3Total',
-                (
-                    select
-                        year_3
-                    from
-                        intervention_data id2
-                    where
-                        intervention_id = g.intervention_id
-                        and header1 = g.header1
-                        and header2 = g.header2
-                        and row_name =(
-                            select
-                                mapping ->(g.header1) ->>(g.header2)
-                            from
-                                totalfields
-                        )
-                ),
-                'year4Total',
-                (
-                    select
-                        year_4
-                    from
-                        intervention_data id2
-                    where
-                        intervention_id = g.intervention_id
-                        and header1 = g.header1
-                        and header2 = g.header2
-                        and row_name =(
-                            select
-                                mapping ->(g.header1) ->>(g.header2)
-                            from
-                                totalfields
-                        )
-                ),
-                'year5Total',
-                (
-                    select
-                        year_5
-                    from
-                        intervention_data id2
-                    where
-                        intervention_id = g.intervention_id
-                        and header1 = g.header1
-                        and header2 = g.header2
-                        and row_name =(
-                            select
-                                mapping ->(g.header1) ->>(g.header2)
-                            from
-                                totalfields
-                        )
-                ),
-                'year6Total',
-                (
-                    select
-                        year_6
-                    from
-                        intervention_data id2
-                    where
-                        intervention_id = g.intervention_id
-                        and header1 = g.header1
-                        and header2 = g.header2
-                        and row_name =(
-                            select
-                                mapping ->(g.header1) ->>(g.header2)
-                            from
-                                totalfields
-                        )
-                ),
-                'year7Total',
-                (
-                    select
-                        year_7
-                    from
-                        intervention_data id2
-                    where
-                        intervention_id = g.intervention_id
-                        and header1 = g.header1
-                        and header2 = g.header2
-                        and row_name =(
-                            select
-                                mapping ->(g.header1) ->>(g.header2)
-                            from
-                                totalfields
-                        )
-                ),
-                'year8Total',
-                (
-                    select
-                        year_8
-                    from
-                        intervention_data id2
-                    where
-                        intervention_id = g.intervention_id
-                        and header1 = g.header1
-                        and header2 = g.header2
-                        and row_name =(
-                            select
-                                mapping ->(g.header1) ->>(g.header2)
-                            from
-                                totalfields
-                        )
-                ),
-                'year9Total',
-                (
-                    select
-                        year_9
-                    from
-                        intervention_data id2
-                    where
-                        intervention_id = g.intervention_id
-                        and header1 = g.header1
-                        and header2 = g.header2
-                        and row_name =(
-                            select
-                                mapping ->(g.header1) ->>(g.header2)
-                            from
-                                totalfields
-                        )
-                )
+            'costBreakdown',
+            json_agg(data),
+            'year0Total',
+            (
+                select
+                    year_0
+                from
+                    intervention_data id2
+                where
+                    intervention_id = g.intervention_id
+                    and header1 = g.header1
+                    and header2 = g.header2
+                    and row_name =(
+                        select
+                            mapping ->(g.header1) ->>(g.header2)
+                        from
+                            totalfields
+                    )
+            ),
+            'year1Total',
+            (
+                select
+                    year_1
+                from
+                    intervention_data id2
+                where
+                    intervention_id = g.intervention_id
+                    and header1 = g.header1
+                    and header2 = g.header2
+                    and row_name =(
+                        select
+                            mapping ->(g.header1) ->>(g.header2)
+                        from
+                            totalfields
+                    )
+            ),
+            'year2Total',
+            (
+                select
+                    year_2
+                from
+                    intervention_data id2
+                where
+                    intervention_id = g.intervention_id
+                    and header1 = g.header1
+                    and header2 = g.header2
+                    and row_name =(
+                        select
+                            mapping ->(g.header1) ->>(g.header2)
+                        from
+                            totalfields
+                    )
+            ),
+            'year3Total',
+            (
+                select
+                    year_3
+                from
+                    intervention_data id2
+                where
+                    intervention_id = g.intervention_id
+                    and header1 = g.header1
+                    and header2 = g.header2
+                    and row_name =(
+                        select
+                            mapping ->(g.header1) ->>(g.header2)
+                        from
+                            totalfields
+                    )
+            ),
+            'year4Total',
+            (
+                select
+                    year_4
+                from
+                    intervention_data id2
+                where
+                    intervention_id = g.intervention_id
+                    and header1 = g.header1
+                    and header2 = g.header2
+                    and row_name =(
+                        select
+                            mapping ->(g.header1) ->>(g.header2)
+                        from
+                            totalfields
+                    )
+            ),
+            'year5Total',
+            (
+                select
+                    year_5
+                from
+                    intervention_data id2
+                where
+                    intervention_id = g.intervention_id
+                    and header1 = g.header1
+                    and header2 = g.header2
+                    and row_name =(
+                        select
+                            mapping ->(g.header1) ->>(g.header2)
+                        from
+                            totalfields
+                    )
+            ),
+            'year6Total',
+            (
+                select
+                    year_6
+                from
+                    intervention_data id2
+                where
+                    intervention_id = g.intervention_id
+                    and header1 = g.header1
+                    and header2 = g.header2
+                    and row_name =(
+                        select
+                            mapping ->(g.header1) ->>(g.header2)
+                        from
+                            totalfields
+                    )
+            ),
+            'year7Total',
+            (
+                select
+                    year_7
+                from
+                    intervention_data id2
+                where
+                    intervention_id = g.intervention_id
+                    and header1 = g.header1
+                    and header2 = g.header2
+                    and row_name =(
+                        select
+                            mapping ->(g.header1) ->>(g.header2)
+                        from
+                            totalfields
+                    )
+            ),
+            'year8Total',
+            (
+                select
+                    year_8
+                from
+                    intervention_data id2
+                where
+                    intervention_id = g.intervention_id
+                    and header1 = g.header1
+                    and header2 = g.header2
+                    and row_name =(
+                        select
+                            mapping ->(g.header1) ->>(g.header2)
+                        from
+                            totalfields
+                    )
+            ),
+            'year9Total',
+            (
+                select
+                    year_9
+                from
+                    intervention_data id2
+                where
+                    intervention_id = g.intervention_id
+                    and header1 = g.header1
+                    and header2 = g.header2
+                    and row_name =(
+                        select
+                            mapping ->(g.header1) ->>(g.header2)
+                        from
+                            totalfields
+                    )
             )
         ) as d
     from
@@ -251,21 +251,30 @@ gov_su_agg as (
         header1,
         header2,
         intervention_id
+),
+su_agg2 as (
+    select
+        intervention_id,
+        header1,
+        json_build_object('category', header1, 'costs', array_agg(d)) as recurring_costs
+    from
+        gov_su_agg
+    where
+        header1 in (
+            'Recurring premix costs',
+            'Government-related recurring monitoring and management costs ',
+            'Industry-related recurring fortification costs'
+        )
+    group by
+        intervention_id,
+        header1
 )
 select
     intervention_id,
-    header1,
-    jsonb_object_aggregate(d :: jsonb)
+    array_agg(recurring_costs) as recurring_costs
 from
-    gov_su_agg
-where
-    header1 in (
-        'Recurring premix costs',
-        'Government-related recurring monitoring and management costs ',
-        'Industry-related recurring fortification costs'
-    )
+    su_agg2
 group by
-    intervention_id,
-    header1;
+    intervention_id;
 
 comment ON view intervention_recurring_costs IS 'Extract intervention recurring cost rows for a given intervention';

--- a/db/objects/intervention_costings/R__107_intervention-recurring-costs.sql
+++ b/db/objects/intervention_costings/R__107_intervention-recurring-costs.sql
@@ -55,7 +55,7 @@ gov_su as (
             year_9
         ) as data
     from
-        intervention_data id --where header1 = 'Government-related start-up/scale-up costs' --and header2 = 'Planning'
+        intervention_data id
 ),
 gov_su_agg as (
     select

--- a/db/objects/intervention_costings/R__107_intervention-recurring-costs.sql
+++ b/db/objects/intervention_costings/R__107_intervention-recurring-costs.sql
@@ -1,12 +1,5 @@
-CREATE
-or replace AGGREGATE jsonb_object_aggregate(jsonb) (
-    SFUNC = 'jsonb_concat',
-    STYPE = jsonb,
-    INITCOND = '{}'
-);
-
-CREATE
-OR REPLACE view intervention_recurring_costs AS with totalfields as (
+CREATE OR REPLACE view intervention_recurring_costs AS 
+with totalfields as (
     select
         '{
 		"Recurring premix costs": {


### PR DESCRIPTION
Very much doubled down on using the various json aggregation functions to expose the data rows in more meaningful structures.  All data values are extracted with their associated row_index which can be used by the API for updating data values

`intervention_list` - Summary view of intervention table along with 10year cost total field
`intervention_baseline_assumptions` - Extracts baseline assumption rows (fortified/potentially fortified)
`intervention_food_vehicle` - Extracts food vehicle rows, aggregates appropriately plus text splitting for micronutrients/compounds etc
`intervention_industry_info` - Extracts rows for industry info
`intervention_monitoring_info` - Extracts rows for monitoring info
`intervention_startup_scaleup_costs` - Extracts su-su costs (year totals plus aggregated by sub category breakdowns)\
`intervention_recurring_costs` - Extracts recurring costs (year totals plus aggregated by sub category breakdowns)