### PR TITLE
feat: add basic lock flag and check trigger for intervention_data updates

### DIFF
--- a/db/objects/intervention_costings/R__108_create_derived_intervention.sql
+++ b/db/objects/intervention_costings/R__108_create_derived_intervention.sql
@@ -24,6 +24,7 @@ insert into intervention (
 	, file_name 
 	, base_year 
 	, is_premade 
+	, is_locked
 	, parent_intervention 
 )
 select 
@@ -37,10 +38,14 @@ select
 	, 'User Defined' as file_name
 	, base_year
 	, false as is_premade 
+	, false as is_locked
 	, _parent_id as parent_intervention
 from intervention where id = _parent_id
 returning id INTO _new_id
 ;
+
+-- Lock the parent intervention
+update intervention set is_locked = '1' where id = _parent_id;
 
 -- Duplicate intervention_data rows from
 -- parent intervention with the new intervention_id

--- a/db/objects/intervention_costings/V0.1.0.210__intervention.sql
+++ b/db/objects/intervention_costings/V0.1.0.210__intervention.sql
@@ -11,6 +11,7 @@ CREATE TABLE intervention(
 	file_name                    text,
     base_year                    integer,
     is_premade                   boolean,
+    is_locked                    boolean,
     parent_intervention          integer    REFERENCES intervention(id)
 )
 ;
@@ -26,6 +27,7 @@ COMMENT ON COLUMN intervention.program_status IS 'A description of the stage the
 COMMENT ON COLUMN intervention.file_name IS 'If the data is imported, what the name of the imported file is';
 COMMENT ON COLUMN intervention.base_year is 'the actual year (Common Era) from when the intervention program is to start its calculations, e.g. 2026. As opposed to "year 3".';
 COMMENT ON COLUMN intervention.is_premade is 'Whether this intervention is pre-created by professionals, or whether this is an intervention where an end-user has customised some values';
+COMMENT ON COLUMN intervention.is_locked is 'Whether this intervention is locked against editing (read-only)';
 COMMENT ON COLUMN intervention.parent_intervention IS 'If this intervention has been created by a user, this shows the id of the intervetnion used as a template.';
 
 

--- a/db/objects/intervention_costings/V01.01.212__intervention_data_trigger.sql
+++ b/db/objects/intervention_costings/V01.01.212__intervention_data_trigger.sql
@@ -1,0 +1,26 @@
+CREATE OR REPLACE FUNCTION check_intervention_lock_state()
+  RETURNS TRIGGER AS 
+  
+  $$
+  DECLARE
+   _lock_state   boolean;  -- lock_state of new intervention
+   _intervention_id numeric;
+begin
+	
+  SELECT new.intervention_id into _intervention_id;
+	
+  execute format('SELECT is_locked from "%s".intervention WHERE id = %s',TG_TABLE_SCHEMA, _intervention_id)
+   INTO _lock_state;
+
+  IF _lock_state
+  THEN
+    RAISE EXCEPTION 'Intervention [id:%] is locked!',
+    NEW.intervention_id;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER check_lock_state 
+BEFORE UPDATE ON intervention_data 
+FOR EACH ROW EXECUTE PROCEDURE check_intervention_lock_state();


### PR DESCRIPTION
Adds an `is_locked` flag to the interventions table.  This should be set as true at point of creation for premade interventions as they should never be editable.

When a new intervention is created (derived from a parent intervention), that parent intervention should be marked as 'locked'.  This will ensure that the parent data that fed into this intervention can be recalled if needed and won't be updated after the new intervention was forked.  The `create_derived_intervention` function has been updated to set this flag on the parent intervention as part of it's transaction.

The `intervention_list` view has a new field `is_editable` which reflects the union of the is\_premade and is\_locked flags.  The front-end can use this to establish whether to offer the user the option to edit their intervention or only to be able to fork it (front end unlikely to use 'fork' terminology but functionally that is what is happening).

There is a new function and update trigger on the `intervention_data` table.  This checks the state of the is\_locked flag for the corresponding intervention in the intervention table.  If the intervention `is_locked` flag is false the update succeeds.  If it is true, then the update is rejected

_NB: implemented as a trigger and function rather than a check constraint due to the need to access the data in the `intervention` table when the `intervention_data` table is updated, rather than just being a constraint on the table being updated._