### PR TITLE
269 materialized view refresh is  very  slow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,6 @@
 - rename `flyway.conf.template` to `flyway.conf` and fill in the configuration
 - run `flyway migrate` to run all the sql scripts. Run `flyway clean migrate` to delete pre-existing data in the schema and re-create the db objects from scratch
 
+# ci
+
+pipelines are run at https://kwvmxgit.ad.nerc.ac.uk/bmgf-maps/web/database-architecture

--- a/db/objects/R__105__RefreshAllMaterializedViews.sql
+++ b/db/objects/R__105__RefreshAllMaterializedViews.sql
@@ -1,15 +1,19 @@
 CREATE OR REPLACE FUNCTION RefreshAllMaterializedViews(schema_arg TEXT)
-RETURNS INT AS $$
+RETURNS INT
+AS $$
 DECLARE
     r RECORD;
 BEGIN
     RAISE NOTICE 'Refreshing materialized view in schema %', schema_arg;
-    FOR r IN SELECT matviewname FROM pg_matviews WHERE schemaname = schema_arg 
+    FOR r IN
+    	SELECT matviewname, schemaname
+    	FROM pg_matviews
+    	WHERE schemaname = schema_arg
     LOOP
         RAISE NOTICE 'Refreshing %.%', schema_arg, r.matviewname;
-        EXECUTE 'REFRESH MATERIALIZED VIEW ' || schema_arg || '.' || r.matviewname; 
+        EXECUTE 'REFRESH MATERIALIZED VIEW ' || quote_ident(r.schemaname) || '.' || quote_ident(r.matviewname);
     END LOOP;
 
     RETURN 1;
-END 
+END
 $$ LANGUAGE plpgsql;

--- a/db/objects/R__105__RefreshAllMaterializedViews.sql
+++ b/db/objects/R__105__RefreshAllMaterializedViews.sql
@@ -3,17 +3,27 @@ RETURNS INT
 AS $$
 DECLARE
     r RECORD;
+    starttime TIMESTAMP := clock_timestamp();
+    sectionstarttime TIMESTAMP := clock_timestamp();
 BEGIN
-    RAISE NOTICE 'Refreshing materialized view in schema %', schema_arg;
+    RAISE NOTICE 'Refreshing materialized views for schema % at %', quote_ident(schema_arg), current_time;
+
     FOR r IN
     	SELECT matviewname, schemaname
     	FROM pg_matviews
     	WHERE schemaname = schema_arg
+    	AND matviewname NOT IN ('household_deficiency_afe_aggregation') -- TODO: takes a long time
+    	ORDER BY matviewname
     LOOP
         RAISE NOTICE 'Refreshing %.%', schema_arg, r.matviewname;
-        EXECUTE 'REFRESH MATERIALIZED VIEW ' || quote_ident(r.schemaname) || '.' || quote_ident(r.matviewname);
+
+        EXECUTE 'REFRESH MATERIALIZED VIEW ' || quote_ident(r.schemaname) || '.' || r.matviewname;
+
+        RAISE NOTICE '% %', r.matviewname, lpad((clock_timestamp() - sectionstarttime)::text, 75 - length(r.matviewname));
+        sectionstarttime := clock_timestamp();
     END LOOP;
 
+    RAISE NOTICE 'Cumulative time spent is %', clock_timestamp() - starttime ;
     RETURN 1;
 END
 $$ LANGUAGE plpgsql;

--- a/db/objects/household/R__027_household_deficiency_aggregation.sql
+++ b/db/objects/household/R__027_household_deficiency_aggregation.sql
@@ -2,47 +2,53 @@ DROP MATERIALIZED VIEW IF EXISTS household_deficiency_afe_aggregation;
 
 CREATE materialized view household_deficiency_afe_aggregation AS
 SELECT
-    survey_id,
-    fct_source_id,
-    country,
-    aggregation_area_id,
-    aggregation_area_name,
-    aggregation_area_type,
     ST_AsGeoJSON(geometry) AS geometry,
-    micronutrient_id,
-    unit,
-    median(micronutrient_supply) AS dietary_supply,
-    count(household_id) AS household_count,
-    count(household_id) FILTER (
-        WHERE
-            is_deficient
-    ) AS deficient_count,
-    round(
-        (
+    tbl2.*
+FROM aggregation_area
+JOIN (
+    SELECT
+        survey_id,
+        fct_source_id,
+        country,
+        aggregation_area_id,
+        aggregation_area_name,
+        aggregation_area_type,
+        micronutrient_id,
+        unit,
+        median(micronutrient_supply) AS dietary_supply,
+        count(household_id) AS household_count,
+        count(household_id) FILTER (
+            WHERE
+                is_deficient
+        ) AS deficient_count,
+        round(
             (
-                count(household_id) FILTER (
-                    WHERE
-                        is_deficient
-                )
-            ) :: numeric /(count(household_id))
-        ) * 100,
-        2
-    ) AS deficient_percentage,
-    hidp.afe_ear as deficient_value
-FROM
-    household_intake_afe_deficiency_pivot hidp
-    JOIN micronutrient m ON hidp.micronutrient_id = m.id
-    JOIN aggregation_area s ON s.id = hidp.aggregation_area_id WHERE s.type='admin' AND s.admin_level=1
-GROUP BY
-    survey_id,
-    fct_source_id,
-    country,
-    aggregation_area_id,
-    aggregation_area_name,
-    aggregation_area_type,
-    geometry,
-    micronutrient_id,
-    hidp.afe_ear,
-    m.unit;
+                (
+                    count(household_id) FILTER (
+                        WHERE
+                            is_deficient
+                    )
+                ) :: numeric /(count(household_id))
+            ) * 100,
+            2
+        ) AS deficient_percentage,
+        hidp.afe_ear as deficient_value
+    FROM
+        household_intake_afe_deficiency_pivot hidp
+        JOIN micronutrient m ON hidp.micronutrient_id = m.id
+        JOIN aggregation_area s ON s.id = hidp.aggregation_area_id
+    WHERE s.type='admin' AND s.admin_level=1
+    GROUP BY
+        survey_id,
+        fct_source_id,
+        country,
+        aggregation_area_id,
+        aggregation_area_name,
+        aggregation_area_type,
+        micronutrient_id,
+        hidp.afe_ear,
+        m.unit
+) AS tbl2 ON tbl2.aggregation_area_id = aggregation_area.id
+;
 
 COMMENT ON materialized VIEW household_deficiency_afe_aggregation IS 'View to aggregate the household_intake_deficiency_pivot view to provide the median dietary supply and percentage of deficient households per subregion aggregation area';

--- a/db/objects/impact/R__030_impact-total-availability.sql
+++ b/db/objects/impact/R__030_impact-total-availability.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE VIEW IMPACT_TOTAL_FOOD_AVAILABILITY AS
+CREATE OR REPLACE VIEW impact_total_food_availability AS
 
 select
     country


### PR DESCRIPTION
The materialized view was taking over 50 minutes to refresh. This was
due to there being a clause on the view that grouped rows by
ST_AsGeoJSON(geometry), which was very computationally intensive.
Doing the group first and then joining the GeoJSON avoids Postgres
having to sort on a multi-megabyte field


closes #269 