### PR TITLE
Include household_deficency_afe_aggregate in matview refresh

### DIFF
--- a/db/objects/R__105__RefreshAllMaterializedViews.sql
+++ b/db/objects/R__105__RefreshAllMaterializedViews.sql
@@ -12,7 +12,6 @@ BEGIN
     	SELECT matviewname, schemaname
     	FROM pg_matviews
     	WHERE schemaname = schema_arg
-    	AND matviewname NOT IN ('household_deficiency_afe_aggregation') -- TODO: takes a long time
     	ORDER BY matviewname
     LOOP
         RAISE NOTICE 'Refreshing %.%', schema_arg, r.matviewname;


### PR DESCRIPTION
Removes the 'not in' where clause so that the materialised view can be included.

Refresh takes about 3 minutes on my PC.

Closes #293 