### PR TITLE
Integrate consumption compositon matching

### DIFF
--- a/db/objects/R__020_household_intake.sql
+++ b/db/objects/R__020_household_intake.sql
@@ -69,10 +69,10 @@ SELECT
     , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'Fat'           ) as TotalFats_in_g
     , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'Energy'        ) as Energy_in_kCal
     , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'Moisture'      ) as Moisture_in_g
-    , NULL as Energy_in_kJ           -- TODO: When these are added to the micronutrient table, update this view to forward the data
-    , NULL as MonounsaturatedFA_in_g -- TODO: When these are added to the micronutrient table, update this view to forward the data
-    , NULL as PolyunsaturatedFA_in_g -- TODO: When these are added to the micronutrient table, update this view to forward the data
-    , NULL as SaturatedFA_in_g       -- TODO: When these are added to the micronutrient table, update this view to forward the data
+    , NULL::numeric as Energy_in_kJ           -- TODO: When these are added to the micronutrient table, update this view to forward the data
+    , NULL::numeric as MonounsaturatedFA_in_g -- TODO: When these are added to the micronutrient table, update this view to forward the data
+    , NULL::numeric as PolyunsaturatedFA_in_g -- TODO: When these are added to the micronutrient table, update this view to forward the data
+    , NULL::numeric as SaturatedFA_in_g       -- TODO: When these are added to the micronutrient table, update this view to forward the data
 FROM household
 JOIN consumption_composition_match AS ccm ON ccm.household_id = household.id
 LEFT JOIN consumption_items ci ON household.id = ci.household_id AND ci.food_genus_id = ccm.food_genus_id

--- a/db/objects/R__020_household_intake.sql
+++ b/db/objects/R__020_household_intake.sql
@@ -1,111 +1,80 @@
 CREATE OR REPLACE VIEW household_intake AS
 
+WITH consumption_items AS (
     SELECT
-        household.id as household_id
-        , household.survey_id
-        , fooditem.fct_source_id as fct_source_id
-        , aggregation_area.id as aggregation_area_id
-        , aggregation_area.name as aggregation_area_name
-        , aggregation_area.type as aggregation_area_type
-        , sum(Moisture_in_g                  / 100 * amount_consumed_in_g) as Moisture_in_g
-        , sum(Energy_in_kCal                 / 100 * amount_consumed_in_g) as Energy_in_kCal
-        , sum(Energy_in_kJ                   / 100 * amount_consumed_in_g) as Energy_in_kJ
-        , sum(Nitrogen_in_g                  / 100 * amount_consumed_in_g) as Nitrogen_in_g
-        , sum(TotalProtein_in_g              / 100 * amount_consumed_in_g) as TotalProtein_in_g
-        , sum(TotalFats_in_g                 / 100 * amount_consumed_in_g) as TotalFats_in_g
-        , sum(SaturatedFA_in_g               / 100 * amount_consumed_in_g) as SaturatedFA_in_g
-        , sum(MonounsaturatedFA_in_g         / 100 * amount_consumed_in_g) as MonounsaturatedFA_in_g
-        , sum(PolyunsaturatedFA_in_g         / 100 * amount_consumed_in_g) as PolyunsaturatedFA_in_g
-        , sum(Cholesterol_in_mg              / 100 * amount_consumed_in_g) as Cholesterol_in_mg
-        , sum(carbohydrates_in_g             / 100 * amount_consumed_in_g) as carbohydrates_in_g
-        , sum(Fibre_in_g                     / 100 * amount_consumed_in_g) as Fibre_in_g
-        , sum(Ash_in_g                       / 100 * amount_consumed_in_g) as Ash_in_g
-        , sum(Ca_in_mg                       / 100 * amount_consumed_in_g) as Ca_in_mg
-        , sum(Fe_in_mg                       / 100 * amount_consumed_in_g) as Fe_in_mg
-        , sum(Mg_in_mg                       / 100 * amount_consumed_in_g) as Mg_in_mg
-        , sum(P_in_mg                        / 100 * amount_consumed_in_g) as P_in_mg
-        , sum(K_in_mg                        / 100 * amount_consumed_in_g) as K_in_mg
-        , sum(Na_in_mg                       / 100 * amount_consumed_in_g) as Na_in_mg
-        , sum(Zn_in_mg                       / 100 * amount_consumed_in_g) as Zn_in_mg
-        , sum(Cu_in_mg                       / 100 * amount_consumed_in_g) as Cu_in_mg
-        , sum(Mn_in_mcg                      / 100 * amount_consumed_in_g) as Mn_in_mcg
-        , sum(I_in_mcg                       / 100 * amount_consumed_in_g) as I_in_mcg
-        , sum(Se_in_mcg                      / 100 * amount_consumed_in_g) as Se_in_mcg
-        , sum(VitaminA_in_RAE_in_mcg         / 100 * amount_consumed_in_g) as VitaminA_in_RAE_in_mcg
-        , sum(Thiamin_in_mg                  / 100 * amount_consumed_in_g) as Thiamin_in_mg
-        , sum(Riboflavin_in_mg               / 100 * amount_consumed_in_g) as Riboflavin_in_mg
-        , sum(Niacin_in_mg                   / 100 * amount_consumed_in_g) as Niacin_in_mg
-        , sum(VitaminB6_in_mg                / 100 * amount_consumed_in_g) as VitaminB6_in_mg
-        , sum(Folicacid_in_mcg               / 100 * amount_consumed_in_g) as Folicacid_in_mcg
-        , sum(Folate_in_mcg                  / 100 * amount_consumed_in_g) as Folate_in_mcg
-        , sum(VitaminB12_in_mcg              / 100 * amount_consumed_in_g) as VitaminB12_in_mcg
-        , sum(Pantothenate_in_mg             / 100 * amount_consumed_in_g) as Pantothenate_in_mg
-        , sum(Biotin_in_mcg                  / 100 * amount_consumed_in_g) as Biotin_in_mcg
-        , sum(VitaminC_in_mg                 / 100 * amount_consumed_in_g) as VitaminC_in_mg
-        , sum(VitaminD_in_mcg                / 100 * amount_consumed_in_g) as VitaminD_in_mcg
-        , sum(VitaminE_in_mg                 / 100 * amount_consumed_in_g) as VitaminE_in_mg
-        , sum(PhyticAcid_in_mg               / 100 * amount_consumed_in_g) as PhyticAcid_in_mg
-    FROM
-        fooditem
-        JOIN food_genus ON food_genus.id = fooditem.food_genus_id
-        JOIN HOUSEHOLD_CONSUMPTION as hhc ON hhc.food_genus_id = food_genus.id
-        --JOIN HOUSEHOLD_MEMBER as hhm ON hhm.id = hhc.HOUSEHOLD_id
-        JOIN household ON hhc.household_id = household.id
-        JOIN survey on household.survey_id = survey.id
-        JOIN aggregation_area on ST_Contains(aggregation_area.geometry,  household.location) WHERE aggregation_area.type='admin' AND aggregation_area.admin_level=1
-    GROUP BY aggregation_area.id, household.id, fooditem.fct_source_id
-    --ORDER BY household.id
-UNION ALL
-    SELECT
-        household.id as household_id
-        , household.survey_id
-        , individual_intake.fct_source_id as fct_source_id
-        , aggregation_area.id as aggregation_area_id
-        , aggregation_area.name as aggregation_area_name
-        , aggregation_area.type as aggregation_area_type
-        , sum(Moisture_in_g              ) as  Moisture_in_g
-        , sum(Energy_in_kCal             ) as  Energy_in_kCal
-        , sum(Energy_in_kJ               ) as  Energy_in_kJ
-        , sum(Nitrogen_in_g              ) as  Nitrogen_in_g
-        , sum(TotalProtein_in_g          ) as  TotalProtein_in_g
-        , sum(TotalFats_in_g             ) as  TotalFats_in_g
-        , sum(SaturatedFA_in_g           ) as  SaturatedFA_in_g
-        , sum(MonounsaturatedFA_in_g     ) as  MonounsaturatedFA_in_g
-        , sum(PolyunsaturatedFA_in_g     ) as  PolyunsaturatedFA_in_g
-        , sum(Cholesterol_in_mg          ) as  Cholesterol_in_mg
-        , sum(carbohydrates_in_g         ) as  carbohydrates_in_g
-        , sum(Fibre_in_g                 ) as  Fibre_in_g
-        , sum(Ash_in_g                   ) as  Ash_in_g
-        , sum(Ca_in_mg                   ) as  Ca_in_mg
-        , sum(Fe_in_mg                   ) as  Fe_in_mg
-        , sum(Mg_in_mg                   ) as  Mg_in_mg
-        , sum(P_in_mg                    ) as  P_in_mg
-        , sum(K_in_mg                    ) as  K_in_mg
-        , sum(Na_in_mg                   ) as  Na_in_mg
-        , sum(Zn_in_mg                   ) as  Zn_in_mg
-        , sum(Cu_in_mg                   ) as  Cu_in_mg
-        , sum(Mn_in_mcg                  ) as  Mn_in_mcg
-        , sum(I_in_mcg                   ) as  I_in_mcg
-        , sum(Se_in_mcg                  ) as  Se_in_mcg
-        , sum(VitaminA_in_RAE_in_mcg     ) as  VitaminA_in_RAE_in_mcg
-        , sum(Thiamin_in_mg              ) as  Thiamin_in_mg
-        , sum(Riboflavin_in_mg           ) as  Riboflavin_in_mg
-        , sum(Niacin_in_mg               ) as  Niacin_in_mg
-        , sum(VitaminB6_in_mg            ) as  VitaminB6_in_mg
-        , sum(Folicacid_in_mcg           ) as  Folicacid_in_mcg
-        , sum(Folate_in_mcg              ) as  Folate_in_mcg
-        , sum(VitaminB12_in_mcg          ) as  VitaminB12_in_mcg
-        , sum(Pantothenate_in_mg         ) as  Pantothenate_in_mg
-        , sum(Biotin_in_mcg              ) as  Biotin_in_mcg
-        , sum(VitaminC_in_mg             ) as  VitaminC_in_mg
-        , sum(VitaminD_in_mcg            ) as  VitaminD_in_mcg
-        , sum(VitaminE_in_mg             ) as  VitaminE_in_mg
-        , sum(PhyticAcid_in_mg           ) as  PhyticAcid_in_mg
-    FROM individual_intake
-    JOIN household on individual_intake.household_id = household.id
-    JOIN survey on household.survey_id = survey.id
-    JOIN aggregation_area on ST_Contains(aggregation_area.geometry,  household.location) WHERE aggregation_area.type='admin' AND aggregation_area.admin_level=1
-    GROUP BY aggregation_area.id, household.id, individual_intake.fct_source_id
+         hc.food_genus_id
+         , hc.id AS household_consumption_id
+         , NULL AS household_member_consumption_id
+         , h.id AS household_id
+         , hc.original_food_name AS consumption_original_food_name
+         , hc.amount_consumed_in_g
+        FROM
+            household_consumption hc
+            join household h
+            on hc.household_id = h.id
+    union all
+    select
+           hmc.food_genus_id
+         , NULL AS household_consumption_id
+         , hmc.id AS household_member_consumption_id
+         , hh.id AS household_id
+         , hmc.original_food_name
+         , hmc.amount_consumed_in_g
+        FROM
+        household_member_consumption hmc
+        join household_member hhm
+        on hhm.id = hmc.household_member_id
+        join household hh
+        on hhm.household_id = hh.id
+)
+SELECT
+    household.survey_id
+    , household.id AS household_id
+--    , fct_used AS fct_source_id --TODO: we need to figure out how to carry forward the "FCT used" data to the other views and, ultmiately, the API
+    , NULL AS fct_source_id --TODO: we need to figure out how to carry forward the "FCT used" data to the other views and, ultmiately, the API
+    , aggregation_area.id as aggregation_area_id
+    , aggregation_area.name as aggregation_area_name
+    , aggregation_area.type as aggregation_area_type
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'A'             ) as VitaminA_in_RAE_in_mcg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'B6'            ) as VitaminB6_in_mg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'B12'           ) as VitaminB12_in_mcg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'C'             ) as VitaminC_in_mg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'D'             ) as VitaminD_in_mcg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'E'             ) as VitaminE_in_mg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'B1'            ) as Thiamin_in_mg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'B2'            ) as Riboflavin_in_mg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'B3'            ) as Niacin_in_mg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'Folic Acid'    ) as Folicacid_in_mcg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'B9'            ) as Folate_in_mcg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'B5'            ) as Pantothenate_in_mg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'B7'            ) as Biotin_in_mcg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'IP6'           ) as PhyticAcid_in_mg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'Ca'            ) as Ca_in_mg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'Cu'            ) as Cu_in_mg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'Fe'            ) as Fe_in_mg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'Mg'            ) as Mg_in_mg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'Mn'            ) as Mn_in_mcg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'P'             ) as P_in_mg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'K'             ) as K_in_mg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'Na'            ) as Na_in_mg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'Zn'            ) as Zn_in_mg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'I'             ) as I_in_mcg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'N'             ) as Nitrogen_in_g
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'Se'            ) as Se_in_mcg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'Ash'           ) as Ash_in_g
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'Fibre'         ) as Fibre_in_g
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'Carbohydrates' ) as carbohydrates_in_g
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'Cholesterol'   ) as Cholesterol_in_mg
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'Protein'       ) as TotalProtein_in_g
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'Fat'           ) as TotalFats_in_g
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'Energy'        ) as Energy_in_kCal
+    , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'Moisture'      ) as Moisture_in_g
+FROM household
+JOIN consumption_composition_match AS ccm ON ccm.household_id = household.id
+LEFT JOIN consumption_items ci ON household.id = ci.household_id AND ci.food_genus_id = ccm.food_genus_id
+JOIN aggregation_area on ST_Contains(aggregation_area.geometry,  household.location)
+WHERE aggregation_area.type='admin' AND aggregation_area.admin_level=1
+GROUP BY aggregation_area_id, survey_id, household.id
 ;
 
 COMMENT ON VIEW household_intake IS 'View of amount of micronutrients consumed in total by individual households ';

--- a/db/objects/R__020_household_intake.sql
+++ b/db/objects/R__020_household_intake.sql
@@ -69,6 +69,10 @@ SELECT
     , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'Fat'           ) as TotalFats_in_g
     , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'Energy'        ) as Energy_in_kCal
     , sum(micronutrient_composition / 100 * amount_consumed_in_g) FILTER (WHERE micronutrient_id = 'Moisture'      ) as Moisture_in_g
+    , NULL as Energy_in_kJ           -- TODO: When these are added to the micronutrient table, update this view to forward the data
+    , NULL as MonounsaturatedFA_in_g -- TODO: When these are added to the micronutrient table, update this view to forward the data
+    , NULL as PolyunsaturatedFA_in_g -- TODO: When these are added to the micronutrient table, update this view to forward the data
+    , NULL as SaturatedFA_in_g       -- TODO: When these are added to the micronutrient table, update this view to forward the data
 FROM household
 JOIN consumption_composition_match AS ccm ON ccm.household_id = household.id
 LEFT JOIN consumption_items ci ON household.id = ci.household_id AND ci.food_genus_id = ccm.food_genus_id


### PR DESCRIPTION
Integrates the changes from pr #312 and carries the new data forward to the various views and api. Should allows us to close #283, once @bgsandan confirms that it works.

Note/Todos:
- Due to some fooditem columns not existing in the micronutrient table, these columns have NULL data (see #316)
- The `fct_id` is set to NULL, because previously we reported one food composition table when we used some data; now, we reported the source FCT for each micronutrient (#318)

### General Checklist
- [x] Database objects and columns have comments (or not applicable)
- [x] The project README.md has been updated to reflect any changes (or not applicable)
